### PR TITLE
Add uniqueness scoring package with core functionality

### DIFF
--- a/packages/uniqueness/index.d.ts
+++ b/packages/uniqueness/index.d.ts
@@ -1,0 +1,48 @@
+export type Platform = "discord" | "telegram" | "x" | "other";
+export interface UniquenessScope {
+  projectId: string;
+  platform: Platform;
+  channelId?: string;
+  authorId?: string;
+  windowDays?: number;
+  topK?: number;
+}
+export interface Neighbor {
+  messageId: string;
+  cosine: number;
+  jaccard?: number;
+}
+export interface UniquenessResult {
+  score: number;
+  maxCosine: number;
+  maxJaccard?: number;
+  neighbors: Neighbor[];
+}
+export interface UniquenessScorer {
+  score(text: string, scope: UniquenessScope): Promise<UniquenessResult>;
+  upsert(messageId: string, text: string, scope: UniquenessScope): Promise<void>;
+}
+export declare class MemoryUniquenessScorer implements UniquenessScorer {
+  constructor(dim?: number);
+  score(text: string, scope: UniquenessScope): Promise<UniquenessResult>;
+  upsert(messageId: string, text: string, scope: UniquenessScope): Promise<void>;
+}
+export interface PgVectorOptions {
+  dim: number;
+  table?: string;
+}
+export declare class PgVectorUniquenessScorer implements UniquenessScorer {
+  constructor(opts: PgVectorOptions);
+  init(): Promise<void>;
+  score(text: string, scope: UniquenessScope): Promise<UniquenessResult>;
+  upsert(messageId: string, text: string, scope: UniquenessScope): Promise<void>;
+}
+export type Backend = "memory" | "pgvector";
+export interface CreateUniquenessOptions {
+  backend?: Backend;
+  dim?: number;
+  pgvector?: Omit<PgVectorOptions, "dim"> & { dim?: number };
+}
+export declare function createUniquenessScorer(opts?: CreateUniquenessOptions): Promise<UniquenessScorer>;
+
+

--- a/packages/uniqueness/package.json
+++ b/packages/uniqueness/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@ally/uniqueness",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rimraf dist",
+    "dev": "tsc -w -p tsconfig.json",
+    "test": "jest --runInBand"
+  },
+  "dependencies": {
+    "@ally/db": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/jest": "^30.0.0",
+    "jest": "^30.0.5",
+    "rimraf": "^6.0.1",
+    "ts-jest": "^29.4.1",
+    "typescript": "^5.9.2"
+  }
+}
+
+

--- a/packages/uniqueness/src/factory.ts
+++ b/packages/uniqueness/src/factory.ts
@@ -1,0 +1,34 @@
+import type { UniquenessScorer } from "./types.js";
+import { MemoryUniquenessScorer } from "./memory.js";
+export type { PgVectorOptions } from "./pgvector.js";
+
+export type Backend = "memory" | "pgvector";
+
+export interface CreateUniquenessOptions {
+  backend?: Backend;
+  dim?: number;
+  pgvector?: { table?: string; dim?: number };
+}
+
+export async function createUniquenessScorer(opts?: CreateUniquenessOptions): Promise<UniquenessScorer> {
+  const backend = opts?.backend ?? (process.env.UNIQUENESS_BACKEND as Backend) ?? "memory";
+  const dim = opts?.dim ?? Number(process.env.UNIQUENESS_DIM ?? 128);
+
+  if (backend === "pgvector") {
+    try {
+      const mod = await import("./pgvector.js");
+      const scorer = new mod.PgVectorUniquenessScorer({ dim, table: opts?.pgvector?.table });
+      await scorer.init();
+      return scorer;
+    } catch (err) {
+      if (process.env.NODE_ENV !== "test") {
+        console.warn("PgVectorUniquenessScorer init failed; falling back to memory:", (err as Error).message);
+      }
+      return new MemoryUniquenessScorer(dim);
+    }
+  }
+
+  return new MemoryUniquenessScorer(dim);
+}
+
+

--- a/packages/uniqueness/src/index.ts
+++ b/packages/uniqueness/src/index.ts
@@ -1,0 +1,6 @@
+export * from "./types.js";
+export * from "./memory.js";
+export * from "./pgvector.js";
+export * from "./factory.js";
+
+

--- a/packages/uniqueness/src/memory.ts
+++ b/packages/uniqueness/src/memory.ts
@@ -1,0 +1,112 @@
+import type { Neighbor, UniquenessResult, UniquenessScope, UniquenessScorer } from "./types.js";
+
+function normalizeWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function cosineSimilarity(a: Float32Array, b: Float32Array): number {
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < a.length; i++) {
+    const va = a[i];
+    const vb = b[i];
+    dot += va * vb;
+    na += va * va;
+    nb += vb * vb;
+  }
+  if (na === 0 || nb === 0) return 0;
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+
+function shingle(text: string, n = 3): string[] {
+  const tokens = normalizeWhitespace(text).toLowerCase().split(/\W+/).filter(Boolean);
+  const out: string[] = [];
+  for (let i = 0; i + n <= tokens.length; i++) {
+    out.push(tokens.slice(i, i + n).join(" "));
+  }
+  return out;
+}
+
+function jaccard(setA: Set<string>, setB: Set<string>): number {
+  let inter = 0;
+  for (const v of setA) if (setB.has(v)) inter++;
+  const union = setA.size + setB.size - inter;
+  return union === 0 ? 0 : inter / union;
+}
+
+// Todo: Placeholder embedding generator (deterministic, not semantic). Replace in production.
+function cheapDeterministicEmbedding(text: string, dim = 128): Float32Array {
+  const out = new Float32Array(dim);
+  let seed = 2166136261;
+  const s = normalizeWhitespace(text);
+  for (let i = 0; i < s.length; i++) {
+    seed ^= s.charCodeAt(i);
+    seed += (seed << 1) + (seed << 4) + (seed << 7) + (seed << 8) + (seed << 24);
+    const idx = (seed >>> 0) % dim;
+    out[idx] += 1;
+  }
+  return out;
+}
+
+interface MemoryItem {
+  messageId: string;
+  scopeKey: string;
+  embedding: Float32Array;
+  shingles: Set<string>;
+  createdAt: number;
+}
+
+function makeScopeKey(scope: UniquenessScope): string {
+  const w = scope.windowDays ?? 30;
+  return [scope.projectId, scope.platform, scope.channelId ?? "*", scope.authorId ?? "*", `w:${w}`].join("|");
+}
+
+export class MemoryUniquenessScorer implements UniquenessScorer {
+  private items: MemoryItem[] = [];
+  private readonly dim: number;
+
+  constructor(dim = 128) {
+    this.dim = dim;
+  }
+
+  async score(text: string, scope: UniquenessScope): Promise<UniquenessResult> {
+    const topK = scope.topK ?? 10;
+    const now = Date.now();
+    const windowMs = (scope.windowDays ?? 30) * 24 * 60 * 60 * 1000;
+    const minTs = now - windowMs;
+
+    const embedding = cheapDeterministicEmbedding(text, this.dim);
+    const shingles = new Set(shingle(text));
+
+    const scopeKey = makeScopeKey(scope);
+    const candidates = this.items.filter(i => i.scopeKey === scopeKey && i.createdAt >= minTs);
+
+    const scored: Neighbor[] = candidates.map(i => {
+      const cos = cosineSimilarity(embedding, i.embedding);
+      const jac = jaccard(shingles, i.shingles);
+      return { messageId: i.messageId, cosine: cos, jaccard: jac };
+    }).sort((a, b) => b.cosine - a.cosine).slice(0, topK);
+
+    const maxCosine = scored.length ? scored[0].cosine : 0;
+    const maxJaccard = scored.length ? Math.max(...scored.map(n => n.jaccard ?? 0)) : 0;
+    const score = Math.max(0, Math.min(1, 1 - maxCosine));
+
+    return { score, maxCosine, maxJaccard, neighbors: scored };
+  }
+
+  async upsert(messageId: string, text: string, scope: UniquenessScope): Promise<void> {
+    const scopeKey = makeScopeKey(scope);
+    const idx = this.items.findIndex(i => i.messageId === messageId && i.scopeKey === scopeKey);
+    const item: MemoryItem = {
+      messageId,
+      scopeKey,
+      embedding: cheapDeterministicEmbedding(text, this.dim),
+      shingles: new Set(shingle(text)),
+      createdAt: Date.now(),
+    };
+    if (idx >= 0) this.items[idx] = item; else this.items.push(item);
+  }
+}
+
+

--- a/packages/uniqueness/src/pgvector.ts
+++ b/packages/uniqueness/src/pgvector.ts
@@ -1,0 +1,120 @@
+import { getPrismaClient } from "@ally/db";
+import type { Neighbor, UniquenessResult, UniquenessScope, UniquenessScorer } from "./types.js";
+
+// NOTE: Prisma does not yet have first-class vector type here; we'll use raw SQL.
+
+function toVectorLiteral(vec: number[] | Float32Array): string {
+  // pgvector expects [x,y,z]
+  return `'[${Array.from(vec).join(",")}]'`;
+}
+
+async function ensurePgvector(): Promise<void> {
+  const prisma = getPrismaClient();
+  await prisma.$executeRawUnsafe("CREATE EXTENSION IF NOT EXISTS vector");
+}
+
+export interface PgVectorOptions {
+  dim: number;
+  table?: string; // default: message_embeddings
+}
+
+export class PgVectorUniquenessScorer implements UniquenessScorer {
+  private readonly dim: number;
+  private readonly table: string;
+
+  constructor(opts: PgVectorOptions) {
+    this.dim = opts.dim;
+    this.table = opts.table ?? "message_embeddings";
+  }
+
+  async init(): Promise<void> {
+    await ensurePgvector();
+    const prisma = getPrismaClient();
+    const table = this.table;
+    // Create table if not exists
+    await prisma.$executeRawUnsafe(
+      `CREATE TABLE IF NOT EXISTS ${table} (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        platform TEXT NOT NULL,
+        channel_id TEXT,
+        author_id TEXT,
+        embedding vector(${this.dim}) NOT NULL,
+        minhash BYTEA,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      )`
+    );
+    // Basic index; refine to IVFFLAT/HNSW in migrations later
+    await prisma.$executeRawUnsafe(
+      `CREATE INDEX IF NOT EXISTS ${table}_project_platform_created_idx ON ${table}(project_id, platform, created_at DESC)`
+    );
+  }
+
+  private scopeWhere(scope: UniquenessScope, minTsIso: string): string {
+    const conds: string[] = [
+      `project_id = '${scope.projectId.replace(/'/g, "''")}'`,
+      `platform = '${scope.platform.replace(/'/g, "''")}'`,
+      `created_at >= '${minTsIso}'`
+    ];
+    if (scope.channelId) conds.push(`channel_id = '${scope.channelId.replace(/'/g, "''")}'`);
+    // AuthorId optional; we generally do not filter by author for similarity search
+    return conds.join(" AND ");
+  }
+
+  // Placeholder: cheap deterministic embedding; replace with real encoder in higher layer.
+  private embed(text: string): Float32Array {
+    const dim = this.dim;
+    const out = new Float32Array(dim);
+    let seed = 2166136261;
+    const s = text.replace(/\s+/g, " ").trim().toLowerCase();
+    for (let i = 0; i < s.length; i++) {
+      seed ^= s.charCodeAt(i);
+      seed += (seed << 1) + (seed << 4) + (seed << 7) + (seed << 8) + (seed << 24);
+      const idx = seed >>> 0 % dim;
+      out[idx] += 1;
+    }
+    return out;
+  }
+
+  private jaccardApprox(_textA: string, _textB: string): number {
+    // For now, skip MinHash comparison in DB path; can store shingles/minhash later.
+    return 0;
+  }
+
+  async score(text: string, scope: UniquenessScope): Promise<UniquenessResult> {
+    const prisma = getPrismaClient();
+    const topK = scope.topK ?? 10;
+    const now = Date.now();
+    const windowMs = (scope.windowDays ?? 30) * 24 * 60 * 60 * 1000;
+    const minTsIso = new Date(now - windowMs).toISOString();
+
+    const emb = this.embed(text);
+    const vec = toVectorLiteral(emb);
+    const table = this.table;
+    const where = this.scopeWhere(scope, minTsIso);
+    // cosine distance in pgvector: <-> for Euclidean, but for cosine distance you use <%> operator in newer versions; fallback to 1 - cosine
+    const sql = `SELECT id as message_id, 1 - (embedding <#> ${vec}) as cosine
+                 FROM ${table}
+                 WHERE ${where}
+                 ORDER BY embedding <#> ${vec} ASC
+                 LIMIT ${topK}`;
+    // Note: <#> is L2 distance; we approximate cosine via normalized embeddings in a real impl.
+    const rows = await prisma.$queryRawUnsafe<Array<{ message_id: string; cosine: number }>>(sql);
+    const neighbors: Neighbor[] = rows.map((r: any) => ({ messageId: r.message_id, cosine: r.cosine }));
+    const maxCosine = neighbors.length ? neighbors[0].cosine : 0;
+    return { score: Math.max(0, Math.min(1, 1 - maxCosine)), maxCosine, neighbors };
+  }
+
+  async upsert(messageId: string, text: string, scope: UniquenessScope): Promise<void> {
+    const prisma = getPrismaClient();
+    const table = this.table;
+    const emb = this.embed(text);
+    const vec = toVectorLiteral(emb);
+    const sql = `INSERT INTO ${table} (id, project_id, platform, channel_id, author_id, embedding)
+                 VALUES ('${messageId.replace(/'/g, "''")}', '${scope.projectId.replace(/'/g, "''")}', '${scope.platform.replace(/'/g, "''")}', ${scope.channelId ? `'${scope.channelId.replace(/'/g, "''")}'` : 'NULL'}, ${scope.authorId ? `'${scope.authorId.replace(/'/g, "''")}'` : 'NULL'}, ${vec})
+                 ON CONFLICT (id) DO UPDATE SET embedding = EXCLUDED.embedding, project_id = EXCLUDED.project_id, platform = EXCLUDED.platform, channel_id = EXCLUDED.channel_id, author_id = EXCLUDED.author_id`;
+    await prisma.$executeRawUnsafe(sql);
+  }
+}
+
+

--- a/packages/uniqueness/src/types.ts
+++ b/packages/uniqueness/src/types.ts
@@ -1,0 +1,30 @@
+export type Platform = "discord" | "telegram" | "x" | "other";
+
+export interface UniquenessScope {
+  projectId: string;
+  platform: Platform;
+  channelId?: string;
+  authorId?: string;
+  windowDays?: number;
+  topK?: number;
+}
+
+export interface Neighbor {
+  messageId: string;
+  cosine: number;
+  jaccard?: number;
+}
+
+export interface UniquenessResult {
+  score: number; // 0..1 (1 = unique)
+  maxCosine: number;
+  maxJaccard?: number;
+  neighbors: Neighbor[];
+}
+
+export interface UniquenessScorer {
+  score(text: string, scope: UniquenessScope): Promise<UniquenessResult>;
+  upsert(messageId: string, text: string, scope: UniquenessScope): Promise<void>;
+}
+
+

--- a/packages/uniqueness/tsconfig.json
+++ b/packages/uniqueness/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "baseUrl": "../../",
+    "paths": {
+      "@ally/*": ["packages/*/src"]
+    },
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": false,
+    "module": "ESNext",
+    "target": "ES2022",
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}
+
+


### PR DESCRIPTION
Closes #14 
- Introduced the @ally/uniqueness package, implementing a scoring system for message uniqueness across platforms.
- Defined types and interfaces for scoring, including UniquenessScope, UniquenessResult, and scoring algorithms.
- Implemented MemoryUniquenessScorer and PgVectorUniquenessScorer classes for in-memory and PostgreSQL vector-based scoring.
- Added factory function to create appropriate scorer based on configuration.
- Included TypeScript configuration and package metadata for module exports and build scripts.