### PR TITLE
Added Redis stream

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 10
+    # ports: ["6379:6379"] # For running local tests
 
   scoring-service:
     build:

--- a/infra/example.env
+++ b/infra/example.env
@@ -7,7 +7,8 @@ TEC_RAG_API_KEY=supersecret
 TEC_CHAT_ID=theta-kb-01
 
 # Shared infra
-# REDIS_URL=redis://redis:6379
+PROJECT_ID=my-first-project
+REDIS_URL=redis://redis:6379
 POSTGRES_URL=postgresql://ally:secret@postgres/allyhub
 
 # Sentiment service

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -1,0 +1,164 @@
+## @ally/events
+
+Shared event catalog, payload schemas, envelope types, and Redis Streams helpers for ALLY services.
+
+### What’s inside
+- Event catalog and versioning: `@ally/events/catalog`
+- Envelope type: `@ally/events/envelope`
+- Discord payload schemas (zod): `@ally/events/schemas`
+- Redis stream naming + helpers: `@ally/events/streams`
+
+### Install / build
+```bash
+yarn workspace @ally/events build
+yarn workspace @ally/events test
+```
+
+### Exports
+```ts
+// Catalog
+import { EVENT_VERSION, EventType, type EventName } from "@ally/events/catalog";
+
+// Envelope
+import type { EventEnvelope } from "@ally/events/envelope";
+
+// Discord schemas (zod)
+import {
+  DiscordMessageCreated,
+  DiscordMessageUpdated,
+  type DiscordMessageCreated as DiscordMessageCreatedT,
+  type DiscordMessageUpdated as DiscordMessageUpdatedT,
+} from "@ally/events/schemas";
+
+// Redis stream helpers
+import {
+  ingestStreamKey,
+  scoredStreamKey,
+  dlqStreamKey,
+  xaddObj,
+  xreadGroupOnce,
+  xreadGroupLoop,
+  objectToPairs,
+  pairsToObject,
+} from "@ally/events/streams";
+```
+
+### Event catalog
+```ts
+import { EVENT_VERSION, EventType } from "@ally/events/catalog";
+
+// EVENT_VERSION = "v1"
+// EventType = {
+//   DISCORD_MESSAGE_CREATED: "platform.discord.message.created",
+//   DISCORD_MESSAGE_UPDATED: "platform.discord.message.updated",
+//   DISCORD_REACTION_ADDED: "platform.discord.reaction.added",
+// }
+```
+
+### Schemas and envelope
+```ts
+import { DiscordMessageCreated } from "@ally/events/schemas";
+import type { EventEnvelope } from "@ally/events/envelope";
+import { EventType, EVENT_VERSION } from "@ally/events/catalog";
+
+// Validate normalized payload (throws on invalid)
+const payload = DiscordMessageCreated.parse(normalized);
+
+// Create envelope
+const env: EventEnvelope<typeof payload> = {
+  version: EVENT_VERSION,
+  idempotencyKey: `discord:${EventType.DISCORD_MESSAGE_CREATED}:${payload.externalId}:${payload.createdAt}`,
+  projectId: projectId,
+  platform: "discord",
+  type: EventType.DISCORD_MESSAGE_CREATED,
+  ts: new Date().toISOString(),
+  source: { guildId: payload.guildId ?? undefined, channelId: payload.channelId, threadId: payload.threadId ?? undefined },
+  payload,
+};
+```
+
+### Redis stream naming
+```ts
+import { ingestStreamKey, scoredStreamKey, dlqStreamKey } from "@ally/events/streams";
+
+const ingest = ingestStreamKey(projectId, "discord");      // ally:events:ingest:v1:<projectId>:discord
+const scored = scoredStreamKey(projectId);                  // ally:events:scored:v1:<projectId>
+const dlq = dlqStreamKey(projectId);                        // ally:events:dlq:v1:<projectId>
+```
+
+### Publishing (adapter)
+```ts
+import Redis from "ioredis";
+import { ingestStreamKey, xaddObj } from "@ally/events/streams";
+
+const redis = new Redis(process.env.REDIS_URL!);
+const stream = ingestStreamKey(process.env.PROJECT_ID!, "discord");
+
+await xaddObj(redis as any, stream, {
+  version: env.version,
+  idempotencyKey: env.idempotencyKey,
+  projectId: env.projectId,
+  platform: env.platform,
+  type: env.type,
+  ts: env.ts,
+  source: JSON.stringify(env.source),
+  payload: JSON.stringify(env.payload),
+}, { maxLen: { strategy: "approx", count: 100000 } });
+```
+
+### Consuming (worker)
+```ts
+import Redis from "ioredis";
+import { ingestStreamKey, xreadGroupLoop } from "@ally/events/streams";
+
+const redis = new Redis(process.env.REDIS_URL!);
+const projectId = process.env.PROJECT_ID!;
+const stream = ingestStreamKey(projectId, "discord");
+const group = `cg:scoring:v1:${projectId}`;
+const consumer = `scoring-${process.pid}`;
+
+// Ensure group exists
+await redis.xgroup("CREATE", stream, group, "$", "MKSTREAM").catch((e:any) => {
+  if (!String(e?.message).includes("BUSYGROUP")) throw e;
+});
+
+await xreadGroupLoop(redis as any, {
+  group,
+  consumer,
+  streams: [stream],
+  count: 50,
+  blockMs: 5000,
+  handler: async ({ stream, id, fields }) => {
+    // fields is a Record<string,string>
+    const env = {
+      ...fields,
+      source: JSON.parse(fields.source || "{}"),
+      payload: JSON.parse(fields.payload || "{}"),
+    };
+    // route by env.type, score, write to DB, publish to scored stream, etc.
+  },
+});
+```
+
+### Environment
+- `PROJECT_ID` — required; used in stream keys
+- `REDIS_URL` — `redis://redis:6379` in docker-compose; `redis://localhost:6379` locally
+
+`infra/example.env` contains both keys:
+```env
+PROJECT_ID=my-first-project
+REDIS_URL=redis://redis:6379
+```
+
+### Tests
+- Unit tests run by default: `yarn workspace @ally/events test`
+- Redis integration test is opt-in:
+```bash
+REDIS_INTEGRATION=1 REDIS_URL=redis://localhost:6379 yarn workspace @ally/events test
+```
+
+### Versioning
+- Events are versioned via `EVENT_VERSION` (currently "v1").
+- Stream keys include the version so you can evolve formats without breaking consumers.
+
+

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -9,7 +9,8 @@
     ".": "./dist/index.js",
     "./catalog": "./dist/catalog.js",
     "./envelope": "./dist/envelope.js",
-    "./schemas": "./dist/schemas.js"
+    "./schemas": "./dist/schemas.js",
+    "./streams": "./dist/streams.js"
   },
   "files": [
     "dist"

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./catalog.js";
 export * from "./envelope.js";
 export * from "./schemas.js";
+export * from "./streams.js";
 
 

--- a/packages/events/src/streams.ts
+++ b/packages/events/src/streams.ts
@@ -1,0 +1,121 @@
+export type RedisLike = {
+  xadd: (...args: any[]) => Promise<string>;
+  xreadgroup: (...args: any[]) => Promise<any>;
+  xack: (...args: any[]) => Promise<number>;
+  xgroup?: (...args: any[]) => Promise<any>;
+};
+
+// Stream key builders
+export function ingestStreamKey(projectId: string, platform: string): string {
+  return `ally:events:ingest:v1:${projectId}:${platform}`;
+}
+
+export function scoredStreamKey(projectId: string): string {
+  return `ally:events:scored:v1:${projectId}`;
+}
+
+export function dlqStreamKey(projectId: string): string {
+  return `ally:events:dlq:v1:${projectId}`;
+}
+
+// Flatten object into field-value pairs
+export function objectToPairs(obj: Record<string, string>): string[] {
+  return Object.entries(obj).flatMap(([k, v]) => [k, v]);
+}
+
+export type XAddOptions = {
+  maxLen?: { strategy?: "approx" | "exact"; count: number };
+  id?: string | "*"; // default: "*"
+};
+
+// xadd with optional MAXLEN trimming and object payload
+export async function xaddObj(
+  client: RedisLike,
+  stream: string,
+  fields: Record<string, string>,
+  options?: XAddOptions
+): Promise<string> {
+  const args: any[] = [stream];
+  if (options?.maxLen) {
+    args.push("MAXLEN");
+    args.push(options.maxLen.strategy === "exact" ? "=" : "~");
+    args.push(String(options.maxLen.count));
+  }
+  args.push(options?.id ?? "*");
+  args.push(...objectToPairs(fields));
+  return client.xadd(...args);
+}
+
+export type XReadGroupLoopOptions = {
+  group: string;
+  consumer: string;
+  streams: string[];
+  count?: number; // default 50
+  blockMs?: number; // default 5000
+  autoAck?: boolean; // default true
+  abortSignal?: AbortSignal;
+  handler: (params: {
+    stream: string;
+    id: string;
+    fields: Record<string, string>;
+  }) => Promise<void>;
+};
+
+// Helper: convert pairs array [k1,v1,k2,v2,...] to object
+export function pairsToObject(pairs: string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (let i = 0; i < pairs.length; i += 2) {
+    out[pairs[i]] = pairs[i + 1];
+  }
+  return out;
+}
+
+// One-shot read to facilitate tests and controlled polling
+export async function xreadGroupOnce(
+  client: RedisLike,
+  opts: XReadGroupLoopOptions
+): Promise<number> {
+  const count = opts.count ?? 50;
+  const block = opts.blockMs ?? 5000;
+  const placeholders = Array(opts.streams.length).fill(">");
+  const res = await client.xreadgroup(
+    "GROUP",
+    opts.group,
+    opts.consumer,
+    "BLOCK",
+    block,
+    "COUNT",
+    count,
+    "STREAMS",
+    ...opts.streams,
+    ...placeholders
+  );
+  if (!res) return 0;
+  let handled = 0;
+  for (const [streamKey, entries] of res as [string, any[]][]) {
+    for (const [id, pairs] of entries as [string, string[]][]) {
+      await opts.handler({ stream: streamKey, id, fields: pairsToObject(pairs) });
+      handled += 1;
+      if (opts.autoAck !== false) {
+        await client.xack(streamKey, opts.group, id);
+      }
+    }
+  }
+  return handled;
+}
+
+// Continuous polling loop with abort support
+export async function xreadGroupLoop(client: RedisLike, opts: XReadGroupLoopOptions): Promise<void> {
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (opts.abortSignal?.aborted) break;
+    try {
+      await xreadGroupOnce(client, opts);
+    } catch (err) {
+      // Swallow transient errors; production code could emit logs/metrics
+      await new Promise((r) => setTimeout(r, 250));
+    }
+  }
+}
+
+

--- a/packages/events/tests/streams.test.ts
+++ b/packages/events/tests/streams.test.ts
@@ -1,0 +1,49 @@
+import Redis from "ioredis";
+import { ingestStreamKey, scoredStreamKey, dlqStreamKey, xaddObj, xreadGroupOnce } from "../src/streams";
+
+// Integration portion is opt-in to avoid requiring Redis locally.
+const REDIS_URL = process.env.REDIS_URL || "redis://localhost:6379";
+const RUN_INTEGRATION = process.env.REDIS_INTEGRATION === "1";
+
+describe("streams helpers", () => {
+  test("key builders format correctly", () => {
+    expect(ingestStreamKey("p1", "discord")).toBe("ally:events:ingest:v1:p1:discord");
+    expect(scoredStreamKey("p1")).toBe("ally:events:scored:v1:p1");
+    expect(dlqStreamKey("p1")).toBe("ally:events:dlq:v1:p1");
+  });
+
+  (RUN_INTEGRATION ? test : test.skip)("xaddObj writes and xreadGroupOnce reads", async () => {
+    const projectId = `test-${Date.now()}`;
+    const stream = ingestStreamKey(projectId, "discord");
+    const redis = new Redis(REDIS_URL, { connectTimeout: 500 });
+    const group = `cg:${projectId}`;
+    const consumer = `c-${Math.random().toString(36).slice(2)}`;
+
+    try {
+      // create consumer group at $ (new messages only)
+      await redis.xgroup("CREATE", stream, group, "$", "MKSTREAM");
+    } catch (e: any) {
+      if (!String(e?.message).includes("BUSYGROUP")) throw e;
+    }
+
+    // Add two messages with MAXLEN trimming
+    await xaddObj(redis as any, stream, { a: "1" }, { maxLen: { strategy: "approx", count: 1000 } });
+    await xaddObj(redis as any, stream, { a: "2" }, { maxLen: { strategy: "approx", count: 1000 } });
+
+    let handled = 0;
+    const num = await xreadGroupOnce(redis as any, {
+      group,
+      consumer,
+      streams: [stream],
+      count: 10,
+      blockMs: 200,
+      handler: async () => { handled += 1; },
+    });
+    expect(num).toBeGreaterThanOrEqual(1);
+    expect(handled).toBe(num);
+
+    await redis.quit();
+  }, 10_000);
+});
+
+


### PR DESCRIPTION
Closes #36 

## Summary
Implemented in @ally/events with stream key builders (ingestStreamKey, scoredStreamKey, dlqStreamKey), helpers (xaddObj with MAXLEN, xreadGroupOnce, xreadGroupLoop, pairsToObject, objectToPairs), exports via @ally/events/streams and root, plus tests (Redis integration opt-in).
Env updates: infra/example.env includes PROJECT_ID and REDIS_URL; infra/docker-compose.yml starts Redis and passes .env to services.


## Changes Made
- Tests use opt-in integration (set REDIS_INTEGRATION=1) instead of ioredis-mock.
- No changes needed in docker-compose.yml to start Redis; it was already present. We did not add an ingestion-service container yet. (Added port mapping for local testing)

## Notes for Reviewers
PROJECT_ID is available to services; scoring-service doesn’t read it yet in its current code path (will be used by the future worker).