### PR TITLE
Dev discord adapter

### DIFF
--- a/infra/example.env
+++ b/infra/example.env
@@ -11,6 +11,9 @@ PROJECT_ID=my-first-project
 REDIS_URL=redis://redis:6379
 POSTGRES_URL=postgresql://ally:secret@postgres/allyhub
 
+# Discord bot (ingestion)
+DISCORD_BOT_TOKEN=
+
 # Sentiment service
 # HF model selection
 SENTIMENT_MODEL_ID=cardiffnlp/twitter-roberta-base-sentiment-latest

--- a/packages/platform-adapters/discord/README.md
+++ b/packages/platform-adapters/discord/README.md
@@ -20,6 +20,43 @@ This package is part of the monorepo; dependencies are installed at the root:
 yarn install
 ```
 
+### Configure environment (.env)
+
+Add your Discord bot token to `infra/.env` (copy from `infra/example.env`):
+
+```
+DISCORD_BOT_TOKEN=your-bot-token-here
+```
+
+The adapter will pick it up via `process.env.DISCORD_BOT_TOKEN`. You can also pass `token` in `startDiscordAdapter` options if you prefer not to use env variables.
+
+### Setup Discord Bot
+
+1. **Create a Discord Application & Bot**
+   - Go to [Discord Developer Portal](https://discord.com/developers/applications)
+   - Click "New Application" and give it a name
+   - Go to "Bot" section and click "Add Bot"
+   - Copy the bot token (you'll need this for `DISCORD_BOT_TOKEN`)
+
+2. **Enable Required Gateway Intents**
+   - In the Bot section, scroll down to "Privileged Gateway Intents"
+   - Enable these intents:
+     - ✅ **Message Content Intent** (required to read message content)
+     - ✅ **Server Members Intent** (optional, for member info)
+     - ✅ **Presence Intent** (optional, for presence updates)
+
+3. **Invite Bot to Your Server**
+   - Go to "OAuth2" → "URL Generator"
+   - Select scopes: `bot`
+   - Select bot permissions: `Read Messages/View Channels`, `Read Message History`
+   - Copy the generated URL and open it in a browser to invite the bot
+
+4. **Add Token to Environment**
+   - Add your bot token to `infra/.env`:
+   ```env
+   DISCORD_BOT_TOKEN=your-bot-token-here
+   ```
+
 ## Usage
 
 ```ts

--- a/packages/platform-adapters/discord/README.md
+++ b/packages/platform-adapters/discord/README.md
@@ -104,8 +104,9 @@ The adapter wraps these payloads in an envelope containing:
 
 - Build: `yarn build`
 - Tests: `yarn test`
+- E2E Tests: `yarn test:e2e` (requires valid `DISCORD_BOT_TOKEN` in `infra/.env`)
 
-Tests cover the normalization logic in `src/normalizers.ts`.
+Tests cover the normalization logic in `src/normalizers.ts`. The E2E test connects to Discord and logs normalized messages for 5 seconds.
 
 ## Required intents
 

--- a/packages/platform-adapters/discord/README.md
+++ b/packages/platform-adapters/discord/README.md
@@ -1,0 +1,89 @@
+# @ally/platform-adapter-discord
+
+Discord ingestion adapter that connects a Discord bot (discord.js v14) and publishes normalized events to your message bus via a provided Publisher.
+
+## What it does
+
+- Connects to Discord using `DISCORD_BOT_TOKEN` (or an explicit token)
+- Subscribes to message create/update events with the required gateway intents
+- Normalizes raw Discord messages into `@ally/events` schemas:
+  - `DiscordMessageCreated`
+  - `DiscordMessageUpdated`
+- Emits event envelopes using your provided `Publisher`
+- Contains no scoring/business logic
+
+## Install
+
+This package is part of the monorepo; dependencies are installed at the root:
+
+```bash
+yarn install
+```
+
+## Usage
+
+```ts
+import { startDiscordAdapter } from "@ally/platform-adapter-discord";
+
+// implement your Publisher to forward events to your queue/bus
+const publisher = {
+  publish: async (event) => {
+    // e.g., push to Kafka, NATS, SQS, etc.
+    console.log("event", event.type, event.payload.externalId);
+  },
+};
+
+// ensure DISCORD_BOT_TOKEN is set in env or pass token option
+startDiscordAdapter(
+  { projectId: "your-project-id" },
+  publisher
+);
+```
+
+### Options
+
+- `projectId` (string): Project/tenant identifier added to event envelopes
+- `token` (string, optional): If omitted, `process.env.DISCORD_BOT_TOKEN` is used
+- `includeBots` (boolean, optional): When `true`, messages from bot users are included (default: `false`)
+
+## Events and schemas
+
+Normalized payloads conform to `@ally/events`:
+
+- `DiscordMessageCreated`
+- `DiscordMessageUpdated`
+
+The adapter wraps these payloads in an envelope containing:
+
+- `version` (`EVENT_VERSION`)
+- `idempotencyKey`
+- `projectId`
+- `platform` ("discord")
+- `type` (see `EventType` in `@ally/events/catalog`)
+- `ts` (ISO timestamp)
+- `source` (`guildId`, `channelId`, `threadId`)
+
+## Development
+
+- Build: `yarn build`
+- Tests: `yarn test`
+
+Tests cover the normalization logic in `src/normalizers.ts`.
+
+## Required intents
+
+The adapter enables the following gateway intents:
+
+- Guilds
+- Guild Messages
+- Message Content
+- Guild Message Reactions
+- Direct Messages
+- Direct Message Reactions
+
+Make sure these intents are enabled for your bot in the Discord Developer Portal when required.
+
+## Notes
+
+- The adapter only publishes message create/update events for now. Reactions can be added later.
+- No persistence or business/scoring logic is included here.

--- a/packages/platform-adapters/discord/jest.config.cjs
+++ b/packages/platform-adapters/discord/jest.config.cjs
@@ -1,0 +1,20 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.ts$": [
+      "ts-jest",
+      { tsconfig: { module: "commonjs", esModuleInterop: true } }
+    ]
+  },
+  testMatch: [
+    "<rootDir>/tests/**/*.test.ts"
+  ],
+  collectCoverageFrom: [
+    "src/**/*.ts",
+    "!src/**/*.test.ts",
+    "!src/**/*.d.ts"
+  ]
+};
+
+

--- a/packages/platform-adapters/discord/package.json
+++ b/packages/platform-adapters/discord/package.json
@@ -20,7 +20,8 @@
     "build": "tsc -p tsconfig.json",
     "clean": "rimraf dist",
     "dev": "tsc -w -p tsconfig.json",
-    "test": "jest --runInBand"
+    "test": "jest --runInBand",
+    "test:e2e": "DISCORD_E2E=1 jest --runInBand tests/e2e.bot.test.ts"
   },
   "dependencies": {
     "@ally/events": "*",

--- a/packages/platform-adapters/discord/package.json
+++ b/packages/platform-adapters/discord/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
+    "dotenv": "^17.2.1",
     "jest": "^30.0.5",
     "rimraf": "^6.0.1",
     "ts-jest": "^29.4.1",

--- a/packages/platform-adapters/discord/package.json
+++ b/packages/platform-adapters/discord/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@ally/platform-adapter-discord",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    },
+    "./normalizers": "./dist/normalizers.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rimraf dist",
+    "dev": "tsc -w -p tsconfig.json",
+    "test": "jest --runInBand"
+  },
+  "dependencies": {
+    "@ally/events": "*",
+    "discord.js": "^14.15.3"
+  },
+  "devDependencies": {
+    "@types/jest": "^30.0.0",
+    "jest": "^30.0.5",
+    "rimraf": "^6.0.1",
+    "ts-jest": "^29.4.1",
+    "typescript": "^5.9.2"
+  }
+}
+
+

--- a/packages/platform-adapters/discord/src/index.ts
+++ b/packages/platform-adapters/discord/src/index.ts
@@ -1,0 +1,94 @@
+import { Client, GatewayIntentBits, Partials, Message, Events } from "discord.js";
+import { EventEnvelope } from "@ally/events/envelope";
+import { EventType, EVENT_VERSION } from "@ally/events/catalog";
+import { normalizeMessageCreated, normalizeMessageUpdated } from "./normalizers.js";
+
+export type Publisher = {
+  publish: <T>(event: EventEnvelope<T>) => Promise<void>;
+};
+
+export type DiscordAdapterOptions = {
+  projectId: string;
+  token?: string; // optional override; falls back to env
+  includeBots?: boolean; // default false
+};
+
+export function startDiscordAdapter(options: DiscordAdapterOptions, publisher: Publisher) {
+  const token = options.token ?? process.env.DISCORD_BOT_TOKEN;
+  if (!token) {
+    throw new Error("DISCORD_BOT_TOKEN is required to start Discord adapter");
+  }
+
+  const client = new Client({
+    intents: [
+      GatewayIntentBits.Guilds,
+      GatewayIntentBits.GuildMessages,
+      GatewayIntentBits.MessageContent,
+      GatewayIntentBits.GuildMessageReactions,
+      GatewayIntentBits.DirectMessages,
+      GatewayIntentBits.DirectMessageReactions
+    ],
+    partials: [Partials.Message, Partials.Channel, Partials.Reaction]
+  });
+
+  client.on(Events.MessageCreate, async (message: Message) => {
+    if (!options.includeBots && message.author?.bot) return;
+    try {
+      const payload = normalizeMessageCreated(message);
+      const envelope: EventEnvelope<typeof payload> = {
+        version: EVENT_VERSION,
+        idempotencyKey: `discord:${payload.externalId}:created`,
+        projectId: options.projectId,
+        platform: "discord",
+        type: EventType.DISCORD_MESSAGE_CREATED,
+        ts: new Date().toISOString(),
+        source: {
+          guildId: payload.guildId ?? undefined,
+          channelId: payload.channelId,
+          threadId: payload.threadId ?? null
+        },
+        payload
+      };
+      await publisher.publish(envelope);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("Failed to normalize or publish MessageCreate", err);
+    }
+  });
+
+  client.on(Events.MessageUpdate, async (_old, newMessage) => {
+    const message = newMessage.partial ? await newMessage.fetch() : newMessage;
+    if (!options.includeBots && message.author?.bot) return;
+    try {
+      const payload = normalizeMessageUpdated(message);
+      const envelope: EventEnvelope<typeof payload> = {
+        version: EVENT_VERSION,
+        idempotencyKey: `discord:${payload.externalId}:updated:${payload.editedAt}`,
+        projectId: options.projectId,
+        platform: "discord",
+        type: EventType.DISCORD_MESSAGE_UPDATED,
+        ts: new Date().toISOString(),
+        source: {
+          guildId: payload.guildId ?? undefined,
+          channelId: payload.channelId,
+          threadId: payload.threadId ?? null
+        },
+        payload
+      };
+      await publisher.publish(envelope);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("Failed to normalize or publish MessageUpdate", err);
+    }
+  });
+
+  client.login(token).catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error("Discord login failed", err);
+    throw err;
+  });
+
+  return client;
+}
+
+

--- a/packages/platform-adapters/discord/src/normalizers.ts
+++ b/packages/platform-adapters/discord/src/normalizers.ts
@@ -1,0 +1,62 @@
+import { Attachment, Guild, Message, MessageType, ThreadChannel, User } from "discord.js";
+import type { DiscordMessageCreated, DiscordMessageUpdated } from "@ally/events/schemas";
+
+function buildAuthor(user: User | null | undefined) {
+  return {
+    id: user?.id ?? "unknown",
+    username: user?.username,
+    discriminator: (user as any)?.discriminator, // discord.js v14 removed discriminator for usernames; keep optional
+    displayName: (user as any)?.globalName ?? (user as any)?.displayName,
+    isBot: user?.bot ?? false,
+    roles: undefined,
+  };
+}
+
+function buildAttachments(attachments: Map<string, Attachment> | Attachment[]) {
+  const list = Array.isArray(attachments) ? attachments : Array.from(attachments.values());
+  return list.map((a) => ({ id: a.id, url: a.url, contentType: a.contentType ?? undefined }));
+}
+
+function messageLink(message: Message) {
+  const guildId = message.guildId ?? "@me";
+  return `https://discord.com/channels/${guildId}/${message.channelId}/${message.id}`;
+}
+
+function threadIdOf(message: Message): string | null | undefined {
+  const channel = message.channel;
+  if ((channel as ThreadChannel)?.isThread?.()) return (channel as ThreadChannel).id;
+  return (message as any).thread?.id ?? null;
+}
+
+export function normalizeMessageCreated(message: Message): DiscordMessageCreated {
+  const guild: Guild | null = message.guild ?? null;
+  return {
+    externalId: message.id,
+    guildId: guild?.id ?? undefined,
+    channelId: message.channelId,
+    threadId: threadIdOf(message),
+    author: buildAuthor(message.author),
+    content: message.content ?? "",
+    attachments: buildAttachments(message.attachments as any),
+    link: messageLink(message),
+    createdAt: message.createdAt.toISOString(),
+  };
+}
+
+export function normalizeMessageUpdated(message: Message): DiscordMessageUpdated {
+  const guild: Guild | null = message.guild ?? null;
+  return {
+    externalId: message.id,
+    guildId: guild?.id ?? undefined,
+    channelId: message.channelId,
+    threadId: threadIdOf(message),
+    author: buildAuthor(message.author),
+    content: message.content ?? "",
+    attachments: buildAttachments(message.attachments as any),
+    link: messageLink(message),
+    editedAt: (message.editedAt ?? message.createdAt).toISOString(),
+    previousContent: (message as any).previousContent,
+  };
+}
+
+

--- a/packages/platform-adapters/discord/tests/e2e.bot.test.ts
+++ b/packages/platform-adapters/discord/tests/e2e.bot.test.ts
@@ -1,5 +1,10 @@
 import { Client, Events, GatewayIntentBits, Partials, Message } from "discord.js";
 import { normalizeMessageCreated, normalizeMessageUpdated } from "../src/normalizers";
+import { config } from "dotenv";
+import { resolve } from "path";
+
+// Load .env from infra folder
+config({ path: resolve(__dirname, "../../../../infra/.env"), override: true });
 
 // Opt-in E2E: requires DISCORD_E2E=1 and DISCORD_BOT_TOKEN to be set.
 const enabled = process.env.DISCORD_E2E === "1" && !!process.env.DISCORD_BOT_TOKEN;

--- a/packages/platform-adapters/discord/tests/e2e.bot.test.ts
+++ b/packages/platform-adapters/discord/tests/e2e.bot.test.ts
@@ -1,0 +1,49 @@
+import { Client, Events, GatewayIntentBits, Partials, Message } from "discord.js";
+import { normalizeMessageCreated, normalizeMessageUpdated } from "../src/normalizers";
+
+// Opt-in E2E: requires DISCORD_E2E=1 and DISCORD_BOT_TOKEN to be set.
+const enabled = process.env.DISCORD_E2E === "1" && !!process.env.DISCORD_BOT_TOKEN;
+
+(enabled ? describe : describe.skip)("e2e: discord bot connection", () => {
+  test(
+    "connects and logs normalized messages",
+    async () => {
+      const token = process.env.DISCORD_BOT_TOKEN as string;
+      const client = new Client({
+        intents: [
+          GatewayIntentBits.Guilds,
+          GatewayIntentBits.GuildMessages,
+          GatewayIntentBits.MessageContent,
+          GatewayIntentBits.GuildMessageReactions,
+          GatewayIntentBits.DirectMessages,
+          GatewayIntentBits.DirectMessageReactions,
+        ],
+        partials: [Partials.Message, Partials.Channel, Partials.Reaction],
+      });
+
+      client.on(Events.MessageCreate, async (message: Message) => {
+        const payload = normalizeMessageCreated(message);
+        // eslint-disable-next-line no-console
+        console.log("E2E MessageCreate", payload.externalId, payload.content);
+      });
+
+      client.on(Events.MessageUpdate, async (_old, newMessage) => {
+        const message = newMessage.partial ? await newMessage.fetch() : newMessage;
+        const payload = normalizeMessageUpdated(message);
+        // eslint-disable-next-line no-console
+        console.log("E2E MessageUpdate", payload.externalId, payload.editedAt);
+      });
+
+      await client.login(token);
+
+      // wait a short period to observe events
+      await new Promise((res) => setTimeout(res, 5000));
+
+      await client.destroy();
+      expect(client).toBeTruthy();
+    },
+    30000
+  );
+});
+
+

--- a/packages/platform-adapters/discord/tests/normalizers.test.ts
+++ b/packages/platform-adapters/discord/tests/normalizers.test.ts
@@ -1,0 +1,55 @@
+import { normalizeMessageCreated, normalizeMessageUpdated } from "../src/normalizers";
+
+// Minimal fakes for discord.js Message
+function fakeMessage(overrides: Partial<any> = {}) {
+  const createdAt = new Date("2024-01-01T00:00:00Z");
+  const editedAt = new Date("2024-01-01T01:00:00Z");
+  return {
+    id: "123",
+    guild: { id: "guild-1" },
+    guildId: "guild-1",
+    channelId: "channel-1",
+    author: { id: "user-1", username: "alice", bot: false },
+    content: "hello",
+    attachments: new Map(
+      Object.entries({
+        a1: { id: "a1", url: "https://cdn/1.png", contentType: "image/png" }
+      })
+    ),
+    createdAt,
+    editedAt,
+    channel: { id: "channel-1", isThread: () => false },
+    ...overrides,
+  };
+}
+
+describe("normalizers", () => {
+  test("normalizeMessageCreated maps base fields", () => {
+    const m = fakeMessage();
+    const out = normalizeMessageCreated(m as any);
+    expect(out.externalId).toBe("123");
+    expect(out.guildId).toBe("guild-1");
+    expect(out.channelId).toBe("channel-1");
+    expect(out.author.id).toBe("user-1");
+    expect(out.content).toBe("hello");
+    expect(out.attachments?.[0]).toEqual({ id: "a1", url: "https://cdn/1.png", contentType: "image/png" });
+    expect(out.createdAt).toBe("2024-01-01T00:00:00.000Z");
+    expect(out.link).toContain("discord.com/channels/guild-1/channel-1/123");
+  });
+
+  test("normalizeMessageUpdated maps edited fields", () => {
+    const m = fakeMessage({ previousContent: "old" });
+    const out = normalizeMessageUpdated(m as any);
+    expect(out.externalId).toBe("123");
+    expect(out.editedAt).toBe("2024-01-01T01:00:00.000Z");
+    expect(out.previousContent).toBe("old");
+  });
+
+  test("threadId included when thread channel", () => {
+    const m = fakeMessage({ channel: { id: "thread-1", isThread: () => true } });
+    const out = normalizeMessageCreated(m as any);
+    expect(out.threadId).toBe("thread-1");
+  });
+});
+
+

--- a/packages/platform-adapters/discord/tsconfig.json
+++ b/packages/platform-adapters/discord/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "NodeNext",
+    "target": "ES2022",
+    "moduleResolution": "NodeNext",
+    "isolatedModules": true,
+    "declaration": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}
+
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -285,6 +285,71 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@discordjs/builders@^1.11.2":
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/@discordjs/builders/-/builders-1.11.3.tgz#14b8b027e16b73136924faecaf1819b94711647c"
+  integrity sha512-p3kf5eV49CJiRTfhtutUCeivSyQ/l2JlKodW1ZquRwwvlOWmG9+6jFShX6x8rUiYhnP6wKI96rgN/SXMy5e5aw==
+  dependencies:
+    "@discordjs/formatters" "^0.6.1"
+    "@discordjs/util" "^1.1.1"
+    "@sapphire/shapeshift" "^4.0.0"
+    discord-api-types "^0.38.16"
+    fast-deep-equal "^3.1.3"
+    ts-mixer "^6.0.4"
+    tslib "^2.6.3"
+
+"@discordjs/collection@1.5.3":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@discordjs/collection/-/collection-1.5.3.tgz#5a1250159ebfff9efa4f963cfa7e97f1b291be18"
+  integrity sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==
+
+"@discordjs/collection@^2.1.0", "@discordjs/collection@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@discordjs/collection/-/collection-2.1.1.tgz#901917bc538c12b9c3613036d317847baee08cae"
+  integrity sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==
+
+"@discordjs/formatters@^0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@discordjs/formatters/-/formatters-0.6.1.tgz#211bf3eb060d8fe7fa1f020b8be3c4adad00555a"
+  integrity sha512-5cnX+tASiPCqCWtFcFslxBVUaCetB0thvM/JyavhbXInP1HJIEU+Qv/zMrnuwSsX3yWH2lVXNJZeDK3EiP4HHg==
+  dependencies:
+    discord-api-types "^0.38.1"
+
+"@discordjs/rest@^2.5.1", "@discordjs/rest@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@discordjs/rest/-/rest-2.6.0.tgz#8c449b0d5c22a4cd9c655f5d1d53a20b05c37f10"
+  integrity sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==
+  dependencies:
+    "@discordjs/collection" "^2.1.1"
+    "@discordjs/util" "^1.1.1"
+    "@sapphire/async-queue" "^1.5.3"
+    "@sapphire/snowflake" "^3.5.3"
+    "@vladfrangu/async_event_emitter" "^2.4.6"
+    discord-api-types "^0.38.16"
+    magic-bytes.js "^1.10.0"
+    tslib "^2.6.3"
+    undici "6.21.3"
+
+"@discordjs/util@^1.1.0", "@discordjs/util@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@discordjs/util/-/util-1.1.1.tgz#bafcde0faa116c834da1258d78ec237080bbab29"
+  integrity sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g==
+
+"@discordjs/ws@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@discordjs/ws/-/ws-1.2.3.tgz#7cf80d8528366c6810c02b43ca49958ef154c3d4"
+  integrity sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==
+  dependencies:
+    "@discordjs/collection" "^2.1.0"
+    "@discordjs/rest" "^2.5.1"
+    "@discordjs/util" "^1.1.0"
+    "@sapphire/async-queue" "^1.5.2"
+    "@types/ws" "^8.5.10"
+    "@vladfrangu/async_event_emitter" "^2.2.4"
+    discord-api-types "^0.38.1"
+    tslib "^2.6.2"
+    ws "^8.17.0"
+
 "@emnapi/core@^1.4.3":
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.4.5.tgz#bfbb0cbbbb9f96ec4e2c4fd917b7bbe5495ceccb"
@@ -671,6 +736,29 @@
   dependencies:
     "@prisma/debug" "5.22.0"
 
+"@sapphire/async-queue@^1.5.2", "@sapphire/async-queue@^1.5.3":
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/@sapphire/async-queue/-/async-queue-1.5.5.tgz#2b18d402bb920b65b13ad4ed8dfb6c386300dd84"
+  integrity sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==
+
+"@sapphire/shapeshift@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz#86c1b41002ff5d0b2ad21cbc3418b06834b89040"
+  integrity sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    lodash "^4.17.21"
+
+"@sapphire/snowflake@3.5.3":
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/@sapphire/snowflake/-/snowflake-3.5.3.tgz#0c102aa2ec5b34f806e9bc8625fc6a5e1d0a0c6a"
+  integrity sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==
+
+"@sapphire/snowflake@^3.5.3":
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/@sapphire/snowflake/-/snowflake-3.5.5.tgz#33a60ab4231e3cab29e8a0077f342125f2c8d1bd"
+  integrity sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==
+
 "@sinclair/typebox@^0.34.0":
   version "0.34.38"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.34.38.tgz#2365df7c23406a4d79413a766567bfbca708b49d"
@@ -870,6 +958,13 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
 
+"@types/ws@^8.5.10":
+  version "8.18.1"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.18.1.tgz#48464e4bf2ddfd17db13d845467f6070ffea4aa9"
+  integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yargs-parser@*":
   version "21.0.3"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
@@ -983,6 +1078,11 @@
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
   integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
+
+"@vladfrangu/async_event_emitter@^2.2.4", "@vladfrangu/async_event_emitter@^2.4.6":
+  version "2.4.6"
+  resolved "https://registry.yarnpkg.com/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.6.tgz#508b6c45b03f917112a9008180b308ba0e4d1805"
+  integrity sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA==
 
 accepts@~1.3.8:
   version "1.3.8"
@@ -1394,6 +1494,30 @@ diff@^4.0.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
+discord-api-types@^0.38.1, discord-api-types@^0.38.16:
+  version "0.38.21"
+  resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.38.21.tgz#f28d3546869038db247d16e85900f2033b880aa5"
+  integrity sha512-E6KtXUNjZVIYP1GMjmeRdAC1xRql9xtSahRwJYpP74/hJ6Q2i2oTp6ZbFG/FUN0WqtdW2igHDsJyF2u9hV8pHQ==
+
+discord.js@^14.15.3:
+  version "14.22.1"
+  resolved "https://registry.yarnpkg.com/discord.js/-/discord.js-14.22.1.tgz#aa364cf0108b41bac3eaa9fa1aae836d0882a91c"
+  integrity sha512-3k+Kisd/v570Jr68A1kNs7qVhNehDwDJAPe4DZ2Syt+/zobf9zEcuYFvsfIaAOgCa0BiHMfOOKQY4eYINl0z7w==
+  dependencies:
+    "@discordjs/builders" "^1.11.2"
+    "@discordjs/collection" "1.5.3"
+    "@discordjs/formatters" "^0.6.1"
+    "@discordjs/rest" "^2.6.0"
+    "@discordjs/util" "^1.1.1"
+    "@discordjs/ws" "^1.2.3"
+    "@sapphire/snowflake" "3.5.3"
+    discord-api-types "^0.38.16"
+    fast-deep-equal "3.1.3"
+    lodash.snakecase "4.1.1"
+    magic-bytes.js "^1.10.0"
+    tslib "^2.6.3"
+    undici "6.21.3"
+
 dotenv@^16.4.5:
   version "16.6.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.6.1.tgz#773f0e69527a8315c7285d5ee73c4459d20a8020"
@@ -1570,6 +1694,11 @@ express@^4.19.2:
     type-is "~1.6.18"
     utils-merge "1.0.1"
     vary "~1.1.2"
+
+fast-deep-equal@3.1.3, fast-deep-equal@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
@@ -2341,6 +2470,16 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
 
+lodash.snakecase@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
+  integrity sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 lru-cache@^10.2.0:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
@@ -2357,6 +2496,11 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+magic-bytes.js@^1.10.0:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/magic-bytes.js/-/magic-bytes.js-1.12.1.tgz#031fedceb1fc652c1ccd917c6b45a6e8d6554245"
+  integrity sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA==
 
 make-dir@^4.0.0:
   version "4.0.0"
@@ -3101,6 +3245,11 @@ ts-jest@^29.4.1:
     type-fest "^4.41.0"
     yargs-parser "^21.1.1"
 
+ts-mixer@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/ts-mixer/-/ts-mixer-6.0.4.tgz#1da39ceabc09d947a82140d9f09db0f84919ca28"
+  integrity sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==
+
 ts-node@^10.9.2:
   version "10.9.2"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
@@ -3120,7 +3269,7 @@ ts-node@^10.9.2:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-tslib@^2.4.0:
+tslib@^2.4.0, tslib@^2.6.2, tslib@^2.6.3:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -3162,6 +3311,11 @@ undici-types@~7.10.0:
   version "7.10.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.10.0.tgz#4ac2e058ce56b462b056e629cc6a02393d3ff350"
   integrity sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==
+
+undici@6.21.3:
+  version "6.21.3"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.21.3.tgz#185752ad92c3d0efe7a7d1f6854a50f83b552d7a"
+  integrity sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
@@ -3276,6 +3430,11 @@ write-file-atomic@^5.0.1:
   dependencies:
     imurmurhash "^0.1.4"
     signal-exit "^4.0.1"
+
+ws@^8.17.0:
+  version "8.18.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
+  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
 
 xtend@^4.0.0:
   version "4.0.2"


### PR DESCRIPTION
Closes #38 

## Summary
Scaffolded Discord adapter package with `startDiscordAdapter()` function that connects to Discord using discord.js v14, normalizes messages to `@ally/events` schemas, and publishes events via a configurable Publisher interface.

## Changes Made
- Created new package `@ally/platform-adapter-discord` with TypeScript configuration
- Implemented `startDiscordAdapter()` function that connects to Discord with required gateway intents
- Added message normalizers that map Discord.js Message objects to `DiscordMessageCreated`/`DiscordMessageUpdated` schemas
- Created unit tests for normalizers with sample message fixtures
- Added E2E test that connects to Discord and logs normalized messages (opt-in via `DISCORD_E2E=1`)
- Added comprehensive README with setup instructions, usage examples, and Discord bot configuration steps
- Added `DISCORD_BOT_TOKEN` to `infra/example.env` for environment configuration
- Configured Jest for both unit and E2E testing with proper TypeScript support

## Checklist
- [x] Added/updated tests (unit tests + E2E test)
- [x] Updated documentation (README + example.env)
- [x] Verified locally (unit tests pass, E2E test loads env correctly)