### PR TITLE
Create health endpoint and tail stream

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 10
-    # ports: ["6379:6379"] # For running local tests
+    ports: ["6379:6379"] # For running local tests
 
   scoring-service:
     build:
@@ -72,6 +72,8 @@ services:
       dockerfile: services/ingestion-service/Dockerfile
     env_file:
       - ./.env
+    ports:
+      - "8082:8082"
     depends_on:
       redis:
         condition: service_healthy

--- a/package.json
+++ b/package.json
@@ -9,6 +9,12 @@
     ],
     "scripts": {
       "build": "yarn workspaces run build",
-      "dev": "yarn workspaces run dev"
+      "dev": "yarn workspaces run dev",
+      "tail-stream": "node tools/tail-stream.js"
+    },
+    "devDependencies": {
+      "ioredis": "^5.4.1",
+      "ts-node": "^10.9.2",
+      "typescript": "^5.5.4"
     }
   }

--- a/services/ingestion-service/README.md
+++ b/services/ingestion-service/README.md
@@ -83,4 +83,27 @@ docker compose up ingestion-service
 
 ## Health Monitoring
 
+The service provides a health endpoint at `GET /health` that returns:
+
+```json
+{
+  "ok": true,
+  "redis": "connected",
+  "discord": "ready",
+  "stats": {
+    "messagesReceived": 42,
+    "messagesPublished": 40,
+    "messagesFiltered": 2,
+    "errors": 0,
+    "uptime": 120
+  }
+}
+```
+
+- **200 OK**: Service is healthy (Redis connected, Discord ready)
+- **503 Service Unavailable**: Service is unhealthy (Redis disconnected or Discord not ready)
+- **500 Internal Server Error**: Health check failed
+
+The health endpoint is available on port 8082 when running with Docker Compose.
+
 The service performs health checks on startup and logs Redis connection status. Failed Redis connections will cause the service to exit.

--- a/services/ingestion-service/package.json
+++ b/services/ingestion-service/package.json
@@ -13,9 +13,11 @@
     "@ally/platform-adapter-discord": "*",
     "@ally/events": "*",
     "dotenv": "^16.4.5",
+    "express": "^4.19.2",
     "ioredis": "^5.4.1"
   },
   "devDependencies": {
+    "@types/express": "^4.17.21",
     "@types/node": "^20.0.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4"

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,63 @@
+# CLI Tools
+
+This directory contains command-line utilities for debugging and monitoring the Ally platform.
+
+## tail-stream.js
+
+A CLI tool to tail Redis streams and display new events as they arrive. Useful for debugging ingestion and monitoring event flow.
+
+### Usage
+
+```bash
+# Basic usage - tail a stream and show last 10 entries + follow new events
+yarn tail-stream <streamKey>
+
+# Show last N entries before following
+yarn tail-stream <streamKey> <count>
+
+# Examples
+yarn tail-stream ally:my-project:platform.discord.message.created
+yarn tail-stream ally:my-project:platform.discord.message.created 5
+```
+
+### Environment Variables
+
+- `REDIS_URL` - Redis connection string (default: `redis://localhost:6379`)
+
+**Note:** When using Docker Compose, use `REDIS_URL=redis://localhost:6379` to connect to the Redis container.
+
+### Features
+
+- **Recent History**: Shows last N entries before following new events
+- **Real-time Following**: Displays new events as they arrive
+- **Formatted Output**: Pretty-prints event payloads with timestamps
+- **Error Handling**: Graceful error recovery and Ctrl+C handling
+- **Connection Status**: Shows Redis connection status
+
+### Output Format
+
+```
+[2024-01-01T12:00:00.000Z] platform.discord.message.created (discord:created:123456789:2024-01-01T12:00:00.000Z)
+{
+  "externalId": "123456789",
+  "guildId": "guild-123",
+  "channelId": "channel-456",
+  "author": {
+    "id": "user-789",
+    "username": "alice",
+    "isBot": false
+  },
+  "content": "Hello world!",
+  "createdAt": "2024-01-01T12:00:00.000Z"
+}
+---
+```
+
+### Stream Keys
+
+Common stream keys for Ally platform:
+
+- `ally:{PROJECT_ID}:platform.discord.message.created` - Discord message creation events
+- `ally:{PROJECT_ID}:platform.discord.message.updated` - Discord message update events
+
+Replace `{PROJECT_ID}` with your actual project ID (e.g., `my-first-project`).

--- a/tools/tail-stream.js
+++ b/tools/tail-stream.js
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+import { Redis } from 'ioredis';
+import 'dotenv/config';
+
+const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6379';
+
+function parseStreamEntry(entry) {
+  const [id, fields] = entry;
+  return { id, fields };
+}
+
+function formatEvent(entry) {
+  const fields = {};
+  
+  // Convert fields array to object
+  for (let i = 0; i < entry.fields.length; i += 2) {
+    fields[entry.fields[i]] = entry.fields[i + 1];
+  }
+  
+  const timestamp = new Date().toISOString();
+  const type = fields.type || 'unknown';
+  const idempotencyKey = fields.idempotencyKey || 'unknown';
+  
+  let payload = '{}';
+  try {
+    if (fields.payload) {
+      const parsed = JSON.parse(fields.payload);
+      payload = JSON.stringify(parsed, null, 2);
+    }
+  } catch (e) {
+    payload = fields.payload || '{}';
+  }
+  
+  return `[${timestamp}] ${type} (${idempotencyKey})
+${payload}
+---`;
+}
+
+async function tailStream(streamKey, count = 10) {
+  const redis = new Redis(REDIS_URL);
+  
+  try {
+    console.log(`🔍 Connecting to Redis at ${REDIS_URL}`);
+    await redis.ping();
+    console.log(`✅ Redis connected`);
+    
+    console.log(`📊 Tailing stream: ${streamKey}`);
+    console.log(`📈 Showing last ${count} entries + following new events...\n`);
+    
+    // Get last N entries
+    const lastEntries = await redis.xrevrange(streamKey, '+', '-', 'COUNT', count);
+    if (lastEntries.length > 0) {
+      console.log('📜 Recent entries:');
+      for (const entry of lastEntries.reverse()) {
+        const parsed = parseStreamEntry(entry);
+        console.log(formatEvent(parsed));
+      }
+      console.log('\n🔄 Following new events...\n');
+    }
+    
+    // Get the last ID to start following from
+    const lastId = lastEntries.length > 0 ? lastEntries[0][0] : '0';
+    let currentId = lastId;
+    
+    // Follow new events
+    while (true) {
+      try {
+        const newEntries = await redis.xread('BLOCK', 5000, 'STREAMS', streamKey, currentId);
+        
+        if (newEntries && newEntries.length > 0) {
+          for (const stream of newEntries) {
+            const [key, entries] = stream;
+            for (const entry of entries) {
+              const parsed = parseStreamEntry(entry);
+              console.log(formatEvent(parsed));
+              currentId = entry[0];
+            }
+          }
+        }
+      } catch (error) {
+        console.error('❌ Error reading stream:', error);
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      }
+    }
+    
+  } catch (error) {
+    console.error('❌ Failed to connect to Redis:', error);
+    process.exit(1);
+  }
+}
+
+// CLI argument parsing
+const args = process.argv.slice(2);
+const streamKey = args[0];
+const count = args[1] ? parseInt(args[1], 10) : 10;
+
+if (!streamKey) {
+  console.log('Usage: node tools/tail-stream.js <streamKey> [count]');
+  console.log('');
+  console.log('Examples:');
+  console.log('  node tools/tail-stream.js ally:my-project:platform.discord.message.created');
+  console.log('  node tools/tail-stream.js ally:my-project:platform.discord.message.created 5');
+  console.log('');
+  console.log('Environment:');
+  console.log('  REDIS_URL - Redis connection string (default: redis://localhost:6379)');
+  process.exit(1);
+}
+
+// Handle Ctrl+C gracefully
+process.on('SIGINT', () => {
+  console.log('\n👋 Stopping stream tail...');
+  process.exit(0);
+});
+
+tailStream(streamKey, count).catch((error) => {
+  console.error('❌ Error:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #42 

## Summary
Add health check endpoint and tail stream CLI tool to ingestion service for quick debugging and real-time monitoring of Discord message ingestion.


## Changes Made
- **Added Express server** to `services/ingestion-service/` with health endpoint at `GET /health`
- **Created tail-stream CLI tool** (`tools/tail-stream.js`) for monitoring Redis streams in real-time
- **Enhanced Docker configuration** to expose Redis port 6379 for local tool access
- **Added comprehensive health monitoring** with Redis connection, Discord adapter status, and statistics
- **Updated dependencies** to include Express and related packages
- **Fixed Express server binding** to properly listen on `0.0.0.0:8082` in Docker containers
- **Added documentation** for both health endpoint and tail-stream tool usage

## Checklist
- [x] **Health endpoint returns 200** - `GET /health` returns comprehensive status with Redis/Discord health
- [x] **Tail tool shows new events as they arrive** - Real-time following with formatted JSON output