### PR TITLE
Add Discord Message Reaction Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "scripts": {
       "build": "yarn workspaces run build",
       "dev": "yarn workspaces run dev",
-      "tail-stream": "node tools/tail-stream.js"
+      "tail-stream": "node tools/tail-stream.js",
+      "tail-all-discord": "node tools/tail-all-discord.js"
     },
     "devDependencies": {
       "ioredis": "^5.4.1",

--- a/packages/events/src/catalog.ts
+++ b/packages/events/src/catalog.ts
@@ -4,6 +4,7 @@ export const EventType = {
   DISCORD_MESSAGE_CREATED: "platform.discord.message.created",
   DISCORD_MESSAGE_UPDATED: "platform.discord.message.updated",
   DISCORD_REACTION_ADDED: "platform.discord.reaction.added",
+  DISCORD_REACTION_REMOVED: "platform.discord.reaction.removed",
 } as const;
 
 export type EventName = typeof EventType[keyof typeof EventType];

--- a/packages/events/src/schemas.ts
+++ b/packages/events/src/schemas.ts
@@ -35,7 +35,28 @@ export const DiscordMessageUpdated = DiscordMessageBase.extend({
   previousContent: z.string().optional(),
 });
 
+export const DiscordEmoji = z.object({
+  id: z.string().nullable().optional(),
+  name: z.string(),
+  animated: z.boolean().optional(),
+});
+
+export const DiscordReactionEvent = z.object({
+  externalId: z.string(),
+  messageId: z.string(),
+  guildId: z.string().nullable().optional(),
+  channelId: z.string(),
+  threadId: z.string().nullable().optional(),
+  author: DiscordAuthor,
+  emoji: DiscordEmoji,
+  messageAuthor: DiscordAuthor,
+  messageContent: z.string(),
+  reactionCount: z.number(),
+  createdAt: z.string(),
+});
+
 export type DiscordMessageCreated = z.infer<typeof DiscordMessageCreated>;
 export type DiscordMessageUpdated = z.infer<typeof DiscordMessageUpdated>;
+export type DiscordReactionEvent = z.infer<typeof DiscordReactionEvent>;
 
 

--- a/packages/platform-adapters/discord/README.md
+++ b/packages/platform-adapters/discord/README.md
@@ -6,9 +6,10 @@ Discord ingestion adapter that connects a Discord bot (discord.js v14) and publi
 
 - Connects to Discord using `DISCORD_BOT_TOKEN` (or an explicit token)
 - Subscribes to message create/update events with the required gateway intents
-- Normalizes raw Discord messages into `@ally/events` schemas:
+- Normalizes raw Discord messages and reactions into `@ally/events` schemas:
   - `DiscordMessageCreated`
   - `DiscordMessageUpdated`
+  - `DiscordReactionEvent` (for both added and removed reactions)
 - Emits event envelopes using your provided `Publisher`
 - Contains no scoring/business logic
 
@@ -90,8 +91,9 @@ startDiscordAdapter(
 
 Normalized payloads conform to `@ally/events`:
 
-- `DiscordMessageCreated`
-- `DiscordMessageUpdated`
+- `DiscordMessageCreated` - New messages
+- `DiscordMessageUpdated` - Edited messages  
+- `DiscordReactionEvent` - Reaction added/removed events
 
 The adapter wraps these payloads in an envelope containing:
 
@@ -126,5 +128,5 @@ Make sure these intents are enabled for your bot in the Discord Developer Portal
 
 ## Notes
 
-- The adapter only publishes message create/update events for now. Reactions can be added later.
+- The adapter publishes message create/update events and reaction add/remove events.
 - No persistence or business/scoring logic is included here.

--- a/services/ingestion-service/README.md
+++ b/services/ingestion-service/README.md
@@ -31,6 +31,8 @@ DISCORD_MIN_MESSAGE_LENGTH=1
 Events are published to Redis streams with keys like:
 - `ally:{PROJECT_ID}:platform.discord.message.created`
 - `ally:{PROJECT_ID}:platform.discord.message.updated`
+- `ally:{PROJECT_ID}:platform.discord.reaction.added`
+- `ally:{PROJECT_ID}:platform.discord.reaction.removed`
 
 Each stream entry contains:
 - `version`: Event schema version

--- a/tools/README.md
+++ b/tools/README.md
@@ -59,5 +59,7 @@ Common stream keys for Ally platform:
 
 - `ally:{PROJECT_ID}:platform.discord.message.created` - Discord message creation events
 - `ally:{PROJECT_ID}:platform.discord.message.updated` - Discord message update events
+- `ally:{PROJECT_ID}:platform.discord.reaction.added` - Discord reaction added events
+- `ally:{PROJECT_ID}:platform.discord.reaction.removed` - Discord reaction removed events
 
 Replace `{PROJECT_ID}` with your actual project ID (e.g., `my-first-project`).

--- a/tools/README.md
+++ b/tools/README.md
@@ -6,6 +6,10 @@ This directory contains command-line utilities for debugging and monitoring the 
 
 A CLI tool to tail Redis streams and display new events as they arrive. Useful for debugging ingestion and monitoring event flow.
 
+## tail-all-discord.js
+
+A CLI tool to follow ALL Discord events for a project simultaneously. Shows message creation, updates, and reaction events in one view.
+
 ### Usage
 
 ```bash
@@ -15,9 +19,13 @@ yarn tail-stream <streamKey>
 # Show last N entries before following
 yarn tail-stream <streamKey> <count>
 
+# Follow ALL Discord events for a project
+yarn tail-all-discord <projectId> [count]
+
 # Examples
 yarn tail-stream ally:my-project:platform.discord.message.created
 yarn tail-stream ally:my-project:platform.discord.message.created 5
+yarn tail-all-discord my-first-project 5
 ```
 
 ### Environment Variables

--- a/tools/tail-all-discord.js
+++ b/tools/tail-all-discord.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+import { Redis } from 'ioredis';
+import 'dotenv/config';
+
+const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6379';
+
+function parseStreamEntry(entry) {
+  const [id, fields] = entry;
+  return { id, fields };
+}
+
+function formatEvent(streamKey, entry) {
+  const fields = {};
+  
+  // Convert fields array to object
+  for (let i = 0; i < entry.fields.length; i += 2) {
+    fields[entry.fields[i]] = entry.fields[i + 1];
+  }
+  
+  const timestamp = new Date().toISOString();
+  const type = fields.type || 'unknown';
+  const idempotencyKey = fields.idempotencyKey || 'unknown';
+  
+  let payload = '{}';
+  try {
+    if (fields.payload) {
+      const parsed = JSON.parse(fields.payload);
+      payload = JSON.stringify(parsed, null, 2);
+    }
+  } catch (e) {
+    payload = fields.payload || '{}';
+  }
+  
+  // Color code different event types
+  const eventType = type.split('.').pop();
+  let colorPrefix = '';
+  switch (eventType) {
+    case 'created':
+      colorPrefix = '📝';
+      break;
+    case 'updated':
+      colorPrefix = '✏️';
+      break;
+    case 'added':
+      colorPrefix = '➕';
+      break;
+    case 'removed':
+      colorPrefix = '➖';
+      break;
+    default:
+      colorPrefix = '📝';
+  }
+  
+  return `[${timestamp}] ${colorPrefix} ${type} (${idempotencyKey})
+📊 Stream: ${streamKey}
+${payload}
+---`;
+}
+
+async function tailAllDiscordEvents(projectId, count = 5) {
+  const redis = new Redis(REDIS_URL);
+  
+  try {
+    console.log(`🔍 Connecting to Redis at ${REDIS_URL}`);
+    await redis.ping();
+    console.log(`✅ Redis connected`);
+    
+    // Define all Discord event streams
+    const streamKeys = [
+      `ally:${projectId}:platform.discord.message.created`,
+      `ally:${projectId}:platform.discord.message.updated`,
+      `ally:${projectId}:platform.discord.reaction.added`,
+      `ally:${projectId}:platform.discord.reaction.removed`
+    ];
+    
+    console.log(`📊 Tailing all Discord events for project: ${projectId}`);
+    console.log(`📈 Showing last ${count} entries per stream + following new events...\n`);
+    
+    // Get last N entries from each stream
+    const streamStates = {};
+    
+    for (const streamKey of streamKeys) {
+      console.log(`📜 Recent entries from ${streamKey}:`);
+      const lastEntries = await redis.xrevrange(streamKey, '+', '-', 'COUNT', count);
+      
+      if (lastEntries.length > 0) {
+        for (const entry of lastEntries.reverse()) {
+          const parsed = parseStreamEntry(entry);
+          console.log(formatEvent(streamKey, parsed));
+        }
+        streamStates[streamKey] = lastEntries[0][0]; // Last ID
+      } else {
+        streamStates[streamKey] = '0'; // Start from beginning
+      }
+      console.log('');
+    }
+    
+    console.log('🔄 Following new events from all streams...\n');
+    
+    // Follow new events from all streams
+    while (true) {
+      try {
+        // Prepare streams and IDs for xread
+        const streams = [];
+        const ids = [];
+        for (const streamKey of streamKeys) {
+          streams.push(streamKey);
+          ids.push(streamStates[streamKey]);
+        }
+        
+        const newEntries = await redis.xread('BLOCK', 5000, 'STREAMS', ...streams, ...ids);
+        
+        if (newEntries && newEntries.length > 0) {
+          for (const stream of newEntries) {
+            const [streamKey, entries] = stream;
+            for (const entry of entries) {
+              const parsed = parseStreamEntry(entry);
+              console.log(formatEvent(streamKey, parsed));
+              streamStates[streamKey] = entry[0]; // Update last ID
+            }
+          }
+        }
+      } catch (error) {
+        console.error('❌ Error reading streams:', error);
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      }
+    }
+    
+  } catch (error) {
+    console.error('❌ Failed to connect to Redis:', error);
+    process.exit(1);
+  }
+}
+
+// CLI argument parsing
+const args = process.argv.slice(2);
+const projectId = args[0];
+const count = args[1] ? parseInt(args[1], 10) : 5;
+
+if (!projectId) {
+  console.log('Usage: node tools/tail-all-discord.js <projectId> [count]');
+  console.log('');
+  console.log('Examples:');
+  console.log('  node tools/tail-all-discord.js my-first-project');
+  console.log('  node tools/tail-all-discord.js my-first-project 10');
+  console.log('');
+  console.log('This will follow all Discord events:');
+  console.log('  - Message created events');
+  console.log('  - Message updated events');
+  console.log('  - Reaction added events');
+  console.log('  - Reaction removed events');
+  console.log('');
+  console.log('Environment:');
+  console.log('  REDIS_URL - Redis connection string (default: redis://localhost:6379)');
+  process.exit(1);
+}
+
+// Handle Ctrl+C gracefully
+process.on('SIGINT', () => {
+  console.log('\n👋 Stopping all Discord event streams...');
+  process.exit(0);
+});
+
+tailAllDiscordEvents(projectId, count).catch((error) => {
+  console.error('❌ Error:', error);
+  process.exit(1);
+});

--- a/tools/tail-all-events.js
+++ b/tools/tail-all-events.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+import { Redis } from 'ioredis';
+import 'dotenv/config';
+
+const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6379';
+
+function parseStreamEntry(entry) {
+  const [id, fields] = entry;
+  return { id, fields };
+}
+
+function formatEvent(streamKey, entry) {
+  const fields = {};
+  
+  // Convert fields array to object
+  for (let i = 0; i < entry.fields.length; i += 2) {
+    fields[entry.fields[i]] = entry.fields[i + 1];
+  }
+  
+  const timestamp = new Date().toISOString();
+  const type = fields.type || 'unknown';
+  const idempotencyKey = fields.idempotencyKey || 'unknown';
+  
+  let payload = '{}';
+  try {
+    if (fields.payload) {
+      const parsed = JSON.parse(fields.payload);
+      payload = JSON.stringify(parsed, null, 2);
+    }
+  } catch (e) {
+    payload = fields.payload || '{}';
+  }
+  
+  // Color code different event types
+  const eventType = type.split('.').pop();
+  let colorPrefix = '';
+  switch (eventType) {
+    case 'created':
+      colorPrefix = '��';
+      break;
+    case 'updated':
+      colorPrefix = '��';
+      break;
+    case 'added':
+      colorPrefix = '➕';
+      break;
+    case 'removed':
+      colorPrefix = '➖';
+      break;
+    default:
+      colorPrefix = '📝';
+  }
+  
+  return `[${timestamp}] ${colorPrefix} ${type} (${idempotencyKey})
+📊 Stream: ${streamKey}
+${payload}
+---`;
+}
+
+async function tailAllEvents(projectId, count = 5) {
+  const redis = new Redis(REDIS_URL);
+  
+  try {
+    console.log(`🔍 Connecting to Redis at ${REDIS_URL}`);
+    await redis.ping();
+    console.log(`✅ Redis connected`);
+    
+    // Define all Discord event streams
+    const streamKeys = [
+      `ally:${projectId}:platform.discord.message.created`,
+      `ally:${projectId}:platform.discord.message.updated`,
+      `ally:${projectId}:platform.discord.reaction.added`,
+      `ally:${projectId}:platform.discord.reaction.removed`
+    ];
+    
+    console.log(`📊 Tailing all Discord events for project: ${projectId}`);
+    console.log(`📈 Showing last ${count} entries per stream + following new events...\n`);
+    
+    // Get last N entries from each stream
+    const streamStates = {};
+    
+    for (const streamKey of streamKeys) {
+      console.log(`📜 Recent entries from ${streamKey}:`);
+      const lastEntries = await redis.xrevrange(streamKey, '+', '-', 'COUNT', count);
+      
+      if (lastEntries.length > 0) {
+        for (const entry of lastEntries.reverse()) {
+          const parsed = parseStreamEntry(entry);
+          console.log(formatEvent(streamKey, parsed));
+        }
+        streamStates[streamKey] = lastEntries[0][0]; // Last ID
+      } else {
+        streamStates[streamKey] = '0'; // Start from beginning
+      }
+      console.log('');
+    }
+    
+    console.log('🔄 Following new events from all streams...\n');
+    
+    // Follow new events from all streams
+    while (true) {
+      try {
+        // Prepare streams and IDs for xread
+        const streams = [];
+        const ids = [];
+        for (const streamKey of streamKeys) {
+          streams.push(streamKey);
+          ids.push(streamStates[streamKey]);
+        }
+        
+        const newEntries = await redis.xread('BLOCK', 5000, 'STREAMS', ...streams, ...ids);
+        
+        if (newEntries && newEntries.length > 0) {
+          for (const stream of newEntries) {
+            const [streamKey, entries] = stream;
+            for (const entry of entries) {
+              const parsed = parseStreamEntry(entry);
+              console.log(formatEvent(streamKey, parsed));
+              streamStates[streamKey] = entry[0]; // Update last ID
+            }
+          }
+        }
+      } catch (error) {
+        console.error('❌ Error reading streams:', error);
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      }
+    }
+    
+  } catch (error) {
+    console.error('❌ Failed to connect to Redis:', error);
+    process.exit(1);
+  }
+}
+
+// CLI argument parsing
+const args = process.argv.slice(2);
+const projectId = args[0];
+const count = args[1] ? parseInt(args[1], 10) : 5;
+
+if (!projectId) {
+  console.log('Usage: node tools/tail-all-events.js <projectId> [count]');
+  console.log('');
+  console.log('Examples:');
+  console.log('  node tools/tail-all-events.js my-first-project');
+  console.log('  node tools/tail-all-events.js my-first-project 10');
+  console.log('');
+  console.log('This will follow all Discord events:');
+  console.log('  - Message created events');
+  console.log('  - Message updated events');
+  console.log('  - Reaction added events');
+  console.log('  - Reaction removed events');
+  console.log('');
+  console.log('Environment:');
+  console.log('  REDIS_URL - Redis connection string (default: redis://localhost:6379)');
+  process.exit(1);
+}
+
+// Handle Ctrl+C gracefully
+process.on('SIGINT', () => {
+  console.log('\n�� Stopping all event streams...');
+  process.exit(0);
+});
+
+tailAllEvents(projectId, count).catch((error) => {
+  console.error('❌ Error:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #44 

## Summary
Added comprehensive Discord message reaction support to the platform adapter, enabling capture and processing of reaction added/removed events alongside existing message events.


## Changes Made
- Extended Event Schemas: Added DiscordReactionEvent and DiscordEmoji schemas to @ally/events
- Reaction Event Types: Added DISCORD_REACTION_REMOVED to event catalog
- Discord Adapter Enhancement:
   - Added MessageReactionAdd and MessageReactionRemove event handlers
   - Implemented normalizeReactionAdded() and normalizeReactionRemoved() functions
   - Proper handling of partial reactions with reaction.fetch()
- Unit Tests: Added comprehensive tests for reaction normalizers
- Documentation Updates: Updated README files to document reaction events
- Monitoring Tools: Created tail-all-discord.js script for monitoring all Discord events
- Redis Stream Integration: Reaction events published to dedicated streams with proper idempotency keys

## Checklist
- [ x ] Discord adapter captures reaction events (both add and remove)
- [ x ] Reaction events normalized to schema with complete message context
- [ x ] Events published to Redis streams with proper idempotency keys
- [ x ] Reaction events include original message context (author, content, messageId)
- [ x ] Same filtering rules apply (guild/channel allowlists, bot filtering)
- [ x ] Tail tool can monitor reaction streams in real-time
- [ x ] Unit tests for reaction normalizers pass