### PR TITLE
Add support for Discord message deletion events

### DIFF
--- a/packages/events/src/catalog.ts
+++ b/packages/events/src/catalog.ts
@@ -3,6 +3,7 @@ export const EVENT_VERSION = "v1" as const;
 export const EventType = {
   DISCORD_MESSAGE_CREATED: "platform.discord.message.created",
   DISCORD_MESSAGE_UPDATED: "platform.discord.message.updated",
+  DISCORD_MESSAGE_DELETED: "platform.discord.message.deleted",
   DISCORD_REACTION_ADDED: "platform.discord.reaction.added",
   DISCORD_REACTION_REMOVED: "platform.discord.reaction.removed",
 } as const;

--- a/packages/events/src/schemas.ts
+++ b/packages/events/src/schemas.ts
@@ -55,8 +55,21 @@ export const DiscordReactionEvent = z.object({
   createdAt: z.string(),
 });
 
+export const DiscordMessageDeleted = z.object({
+  externalId: z.string(),
+  guildId: z.string().nullable().optional(),
+  channelId: z.string(),
+  threadId: z.string().nullable().optional(),
+  author: DiscordAuthor.optional(),
+  content: z.string().optional(),
+  deletedAt: z.string(),
+  deletedBy: DiscordAuthor.optional(),
+  reason: z.string().optional(),
+});
+
 export type DiscordMessageCreated = z.infer<typeof DiscordMessageCreated>;
 export type DiscordMessageUpdated = z.infer<typeof DiscordMessageUpdated>;
 export type DiscordReactionEvent = z.infer<typeof DiscordReactionEvent>;
+export type DiscordMessageDeleted = z.infer<typeof DiscordMessageDeleted>;
 
 

--- a/packages/platform-adapters/discord/README.md
+++ b/packages/platform-adapters/discord/README.md
@@ -6,9 +6,10 @@ Discord ingestion adapter that connects a Discord bot (discord.js v14) and publi
 
 - Connects to Discord using `DISCORD_BOT_TOKEN` (or an explicit token)
 - Subscribes to message create/update events with the required gateway intents
-- Normalizes raw Discord messages and reactions into `@ally/events` schemas:
+- Normalizes raw Discord messages, reactions, and deletions into `@ally/events` schemas:
   - `DiscordMessageCreated`
   - `DiscordMessageUpdated`
+  - `DiscordMessageDeleted`
   - `DiscordReactionEvent` (for both added and removed reactions)
 - Emits event envelopes using your provided `Publisher`
 - Contains no scoring/business logic
@@ -93,6 +94,7 @@ Normalized payloads conform to `@ally/events`:
 
 - `DiscordMessageCreated` - New messages
 - `DiscordMessageUpdated` - Edited messages  
+- `DiscordMessageDeleted` - Deleted messages
 - `DiscordReactionEvent` - Reaction added/removed events
 
 The adapter wraps these payloads in an envelope containing:
@@ -128,5 +130,5 @@ Make sure these intents are enabled for your bot in the Discord Developer Portal
 
 ## Notes
 
-- The adapter publishes message create/update events and reaction add/remove events.
+- The adapter publishes message create/update/delete events and reaction add/remove events.
 - No persistence or business/scoring logic is included here.

--- a/packages/platform-adapters/discord/tests/normalizers.test.ts
+++ b/packages/platform-adapters/discord/tests/normalizers.test.ts
@@ -1,4 +1,4 @@
-import { normalizeMessageCreated, normalizeMessageUpdated, normalizeReactionAdded, normalizeReactionRemoved } from "../src/normalizers";
+import { normalizeMessageCreated, normalizeMessageUpdated, normalizeReactionAdded, normalizeReactionRemoved, normalizeMessageDeleted } from "../src/normalizers";
 
 // Minimal fakes for discord.js Message
 function fakeMessage(overrides: Partial<any> = {}) {
@@ -78,6 +78,28 @@ describe("normalizers", () => {
     const out = normalizeReactionRemoved(reaction as any, message as any);
     expect(out.reactionCount).toBe(3); // count - 1
     expect(out.emoji.name).toBe("👍");
+  });
+
+  test("normalizeMessageDeleted with full message data", () => {
+    const message = fakeMessage();
+    const out = normalizeMessageDeleted(message as any, "channel-123", "guild-456");
+    expect(out.externalId).toBe("123");
+    expect(out.channelId).toBe("channel-1"); // Uses message's channelId
+    expect(out.guildId).toBe("guild-1"); // Uses message's guildId
+    expect(out.author?.id).toBe("user-1");
+    expect(out.content).toBe("hello");
+    expect(out.deletedAt).toBeDefined();
+    expect(out.deletedBy).toBeUndefined();
+  });
+
+  test("normalizeMessageDeleted with partial message data", () => {
+    const out = normalizeMessageDeleted(null, "channel-123", "guild-456");
+    expect(out.externalId).toBe("unknown");
+    expect(out.channelId).toBe("channel-123");
+    expect(out.guildId).toBe("guild-456");
+    expect(out.author).toBeUndefined();
+    expect(out.content).toBeUndefined();
+    expect(out.deletedAt).toBeDefined();
   });
 });
 

--- a/services/ingestion-service/README.md
+++ b/services/ingestion-service/README.md
@@ -31,6 +31,7 @@ DISCORD_MIN_MESSAGE_LENGTH=1
 Events are published to Redis streams with keys like:
 - `ally:{PROJECT_ID}:platform.discord.message.created`
 - `ally:{PROJECT_ID}:platform.discord.message.updated`
+- `ally:{PROJECT_ID}:platform.discord.message.deleted`
 - `ally:{PROJECT_ID}:platform.discord.reaction.added`
 - `ally:{PROJECT_ID}:platform.discord.reaction.removed`
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -67,6 +67,7 @@ Common stream keys for Ally platform:
 
 - `ally:{PROJECT_ID}:platform.discord.message.created` - Discord message creation events
 - `ally:{PROJECT_ID}:platform.discord.message.updated` - Discord message update events
+- `ally:{PROJECT_ID}:platform.discord.message.deleted` - Discord message deletion events
 - `ally:{PROJECT_ID}:platform.discord.reaction.added` - Discord reaction added events
 - `ally:{PROJECT_ID}:platform.discord.reaction.removed` - Discord reaction removed events
 

--- a/tools/tail-all-discord.js
+++ b/tools/tail-all-discord.js
@@ -42,6 +42,9 @@ function formatEvent(streamKey, entry) {
     case 'updated':
       colorPrefix = '✏️';
       break;
+    case 'deleted':
+      colorPrefix = '🗑️';
+      break;
     case 'added':
       colorPrefix = '➕';
       break;
@@ -70,6 +73,7 @@ async function tailAllDiscordEvents(projectId, count = 5) {
     const streamKeys = [
       `ally:${projectId}:platform.discord.message.created`,
       `ally:${projectId}:platform.discord.message.updated`,
+      `ally:${projectId}:platform.discord.message.deleted`,
       `ally:${projectId}:platform.discord.reaction.added`,
       `ally:${projectId}:platform.discord.reaction.removed`
     ];
@@ -146,10 +150,11 @@ if (!projectId) {
   console.log('  node tools/tail-all-discord.js my-first-project 10');
   console.log('');
   console.log('This will follow all Discord events:');
-  console.log('  - Message created events');
-  console.log('  - Message updated events');
-  console.log('  - Reaction added events');
-  console.log('  - Reaction removed events');
+console.log('  - Message created events');
+console.log('  - Message updated events');
+console.log('  - Message deleted events');
+console.log('  - Reaction added events');
+console.log('  - Reaction removed events');
   console.log('');
   console.log('Environment:');
   console.log('  REDIS_URL - Redis connection string (default: redis://localhost:6379)');


### PR DESCRIPTION
Closes #46 

## Summary
Added comprehensive Discord message deletion support to complete the message lifecycle tracking, enabling downstream systems to handle message removals and maintain data consistency across the platform.

## Changes Made
- **Extended Event Schemas**: Added `DiscordMessageDeleted` schema to `@ally/events` with optional fields for partial message data
- **Event Type Addition**: Added `DISCORD_MESSAGE_DELETED` to event catalog
- **Discord Adapter Enhancement**: 
  - Added `MessageDelete` event handler with proper partial message handling
  - Implemented `normalizeMessageDeleted()` function supporting both full and partial message data
  - Robust handling of Discord.js partial messages with `message.partial` checks
- **Unit Tests**: Added comprehensive tests for message deletion normalizer (full and partial data scenarios)
- **Documentation Updates**: Updated all README files to document deletion events
- **Monitoring Tools**: Enhanced `tail-all-discord.js` to include deletion stream with 🗑️ icon
- **Redis Stream Integration**: Deletion events published to dedicated stream with proper idempotency keys

## Screenshots (if UI change)
<!-- Add before/after screenshots -->

## Checklist
- [x] Discord adapter captures `MessageDelete` events from Discord gateway
- [x] Deleted message events normalized to `DiscordMessageDeleted` schema
- [x] Events published to Redis stream with proper idempotency keys
- [x] Deleted message events include available message context (author, content if cached)
- [x] Same filtering rules apply (guild/channel allowlists, bot filtering)
- [x] Tail tool can monitor message deletion stream
- [x] Health endpoint includes statistics for deletion events
- [x] Documentation updated to include deletion events