### PR TITLE
Fix score extraction logic in DiscordEventProcessor to ensure numeric…

### DIFF
--- a/services/scoring-service/src/processors/discordProcessor.ts
+++ b/services/scoring-service/src/processors/discordProcessor.ts
@@ -431,7 +431,7 @@ export class DiscordEventProcessor implements PlatformEventProcessor {
    * Extracts numeric score from breakdown object
    */
   private extractScore(breakdown: any): number {
-    return breakdown.score || breakdown;
+    return typeof breakdown.score === 'number' ? breakdown.score : breakdown;
   }
 
   /**


### PR DESCRIPTION
Closes #93 

## Summary
Fix score extraction logic in DiscordEventProcessor to ensure numeric values are returned correctly

## Changes Made
- update extractScore function