### PR TITLE
Admin service: Update API for Epoch-Based Campaigns

### DIFF
--- a/services/admin-service/README.md
+++ b/services/admin-service/README.md
@@ -1,14 +1,15 @@
 # Admin Service
 
-The Admin Service provides a comprehensive backend API for managing the Ally platform, including user rankings, message scoring analysis, token campaigns, and payout management.
+The Admin Service provides a comprehensive backend API for managing the Ally platform, including user rankings, message scoring analysis, epoch-based token campaigns, and payout management.
 
 ## Features
 
 - **Authentication & Authorization**: JWT-based admin authentication
 - **User Management**: View user rankings, trust scores, and engagement metrics
 - **Message Analysis**: Browse scored messages with detailed breakdowns
-- **Campaign Management**: Create and manage token reward campaigns
-- **Payout Processing**: Handle reward distributions and blockchain transactions
+- **Epoch-Based Campaign Management**: Create and manage recurring token reward campaigns with automatic fund recycling
+- **Epoch Management**: Manual epoch creation, state transitions, and fund tracking
+- **Payout Processing**: Handle reward distributions linked to specific epochs
 - **Analytics Dashboard**: System statistics and activity trends
 
 ## API Endpoints
@@ -29,16 +30,24 @@ The Admin Service provides a comprehensive backend API for managing the Ally pla
 - `GET /api/messages/stats/summary` - Get message statistics
 
 ### Campaigns
-- `GET /api/campaigns` - Get all campaigns
-- `GET /api/campaigns/:id` - Get campaign details
-- `POST /api/campaigns` - Create new campaign
-- `PUT /api/campaigns/:id` - Update campaign
-- `DELETE /api/campaigns/:id` - Delete campaign
+- `GET /api/campaigns` - Get all campaigns with epoch-based filtering (status, isFunded, platform, search)
+- `GET /api/campaigns/:id` - Get campaign details with epoch summary and statistics
+- `POST /api/campaigns` - Create new epoch-based campaign (payoutIntervalSeconds, epochRewardCap, claimWindowSeconds, recycleUnclaimed)
+- `PUT /api/campaigns/:id` - Update campaign (RBAC-guarded)
+- `DELETE /api/campaigns/:id` - Delete campaign (soft delete by setting inactive)
+- `POST /api/campaigns/:id/fund` - Fund campaign and set vault details (isFunded, vaultAddress, fundingTxHash, startDate)
+- `POST /api/campaigns/:id/status` - Update campaign status (DRAFT|ACTIVE|PAUSED|COMPLETED|CANCELED)
 - `POST /api/campaigns/:id/activate` - Activate campaign
 - `POST /api/campaigns/:id/deactivate` - Deactivate campaign
 
+### Epochs (Manual Management)
+- `GET /api/epochs/campaigns/:campaignId/epochs` - List epochs for campaign with filtering (state, date range)
+- `GET /api/epochs/:epochId` - Get epoch details with allocation/claimed amounts and payouts
+- `POST /api/epochs/campaigns/:campaignId/epochs` - Manual create epoch (number, start/end, claimWindowEnds, allocated)
+- `PUT /api/epochs/:epochId` - Manual updates (state, allocated, claimWindowEnds) with guards
+
 ### Payouts
-- `GET /api/payouts` - Get all payouts with filtering
+- `GET /api/payouts` - Get all payouts with filtering (now supports epochId linking)
 - `GET /api/payouts/:id` - Get payout details
 - `POST /api/payouts/process` - Process multiple payouts
 - `POST /api/payouts/:id/cancel` - Cancel a payout
@@ -68,12 +77,22 @@ NODE_ENV=development
 
 ## Database Schema
 
-The admin service uses the following new database tables:
+The admin service uses the following database tables:
 
 - **Admin**: Admin user accounts
-- **Campaign**: Token reward campaigns
-- **Payout**: Individual reward payouts
+- **Campaign**: Epoch-based token reward campaigns with funding status and recurring payout configuration
+- **CampaignEpoch**: Individual payout windows with allocation, claim tracking, and state management
+- **Payout**: Individual reward payouts (now linked to specific epochs)
 - **SystemConfig**: System configuration settings
+
+### Epoch-Based Campaign System
+
+Campaigns now support recurring payouts through epochs:
+
+- **Campaign States**: DRAFT → ACTIVE → PAUSED → COMPLETED → CANCELED
+- **Epoch States**: OPEN → CLAIMING → RECYCLED → EXPIRED → CLOSED
+- **Fund Recycling**: Unclaimed rewards can be automatically recycled back to the campaign pool
+- **Manual Management**: All epoch operations are manual (no automation in admin-service)
 
 ## Security
 
@@ -123,6 +142,48 @@ The admin service integrates with:
 - **Shade Agent**: For blockchain transactions (TODO)
 - **Frontend**: React admin dashboard (TODO)
 
+## Example API Usage
+
+### Create Epoch-Based Campaign
+```bash
+POST /api/campaigns
+{
+  "name": "Weekly Discord Rewards",
+  "description": "Reward active Discord contributors weekly",
+  "tokenSymbol": "ALLY",
+  "isNative": true,
+  "chainId": "near",
+  "totalRewardPool": "1000000000000000000000", // 1000 tokens
+  "payoutIntervalSeconds": 604800, // 1 week
+  "epochRewardCap": "100000000000000000000", // 100 tokens per epoch
+  "claimWindowSeconds": 604800, // 7 days to claim
+  "recycleUnclaimed": true,
+  "platforms": ["discord"]
+}
+```
+
+### Fund Campaign
+```bash
+POST /api/campaigns/{id}/fund
+{
+  "vaultAddress": "0x123...",
+  "fundingTxHash": "0xabc...",
+  "startDate": "2024-01-01T00:00:00Z"
+}
+```
+
+### Create Epoch
+```bash
+POST /api/epochs/campaigns/{id}/epochs
+{
+  "epochNumber": 1,
+  "epochStart": "2024-01-01T00:00:00Z",
+  "epochEnd": "2024-01-08T00:00:00Z",
+  "claimWindowEnds": "2024-01-15T00:00:00Z",
+  "allocated": "100000000000000000000"
+}
+```
+
 ## TODO
 
 - [ ] Integrate with shade-agent service for actual blockchain transactions
@@ -132,3 +193,5 @@ The admin service integrates with:
 - [ ] Create admin role management system
 - [ ] Add bulk operations for payouts
 - [ ] Implement data export functionality
+- [ ] Add automated epoch creation service (external to admin-service)
+- [ ] Add automated fund recycling service (external to admin-service)

--- a/services/admin-service/src/index.ts
+++ b/services/admin-service/src/index.ts
@@ -7,6 +7,7 @@ import { authRoutes } from './routes/auth';
 import { userRoutes } from './routes/users';
 import { messageRoutes } from './routes/messages';
 import { campaignRoutes } from './routes/campaigns';
+import { epochRoutes } from './routes/epochs';
 import { payoutRoutes } from './routes/payouts';
 import { statsRoutes } from './routes/stats';
 import { authenticateToken } from './middleware/auth';
@@ -49,6 +50,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api/users', authenticateToken, userRoutes);
 app.use('/api/messages', authenticateToken, messageRoutes);
 app.use('/api/campaigns', authenticateToken, campaignRoutes);
+app.use('/api/epochs', authenticateToken, epochRoutes);
 app.use('/api/payouts', authenticateToken, payoutRoutes);
 app.use('/api/stats', authenticateToken, statsRoutes);
 

--- a/services/admin-service/src/routes/epochs.ts
+++ b/services/admin-service/src/routes/epochs.ts
@@ -1,0 +1,352 @@
+import { Router, Request, Response } from 'express';
+import * as Joi from 'joi';
+import { prisma } from '../db/client';
+import { AuthenticatedRequest } from '../middleware/auth';
+
+const router = Router();
+
+// Validation schemas
+const createEpochSchema = Joi.object({
+  epochNumber: Joi.number().integer().min(1).required(),
+  epochStart: Joi.date().required(),
+  epochEnd: Joi.date().greater(Joi.ref('epochStart')).required(),
+  claimWindowEnds: Joi.date().greater(Joi.ref('epochEnd')).required(),
+  allocated: Joi.string().pattern(/^\d+$/).required(),
+  state: Joi.string().valid('OPEN', 'CLAIMING', 'RECYCLED', 'EXPIRED', 'CLOSED').default('OPEN')
+});
+
+const updateEpochSchema = Joi.object({
+  state: Joi.string().valid('OPEN', 'CLAIMING', 'RECYCLED', 'EXPIRED', 'CLOSED').optional(),
+  allocated: Joi.string().pattern(/^\d+$/).optional(),
+  claimWindowEnds: Joi.date().optional(),
+  claimed: Joi.string().pattern(/^\d+$/).optional(),
+  recycledAt: Joi.date().optional()
+});
+
+const epochQuerySchema = Joi.object({
+  page: Joi.number().integer().min(1).default(1),
+  limit: Joi.number().integer().min(1).max(100).default(20),
+  sortBy: Joi.string().valid('epochNumber', 'epochStart', 'epochEnd', 'createdAt').default('epochNumber'),
+  sortOrder: Joi.string().valid('asc', 'desc').default('asc'),
+  state: Joi.string().valid('OPEN', 'CLAIMING', 'RECYCLED', 'EXPIRED', 'CLOSED').optional(),
+  startDate: Joi.date().optional(),
+  endDate: Joi.date().optional()
+});
+
+// GET /api/campaigns/:campaignId/epochs - List epochs for campaign
+router.get('/campaigns/:campaignId/epochs', async (req: Request, res: Response) => {
+  try {
+    const { campaignId } = req.params;
+    const { error, value } = epochQuerySchema.validate(req.query);
+    
+    if (error) {
+      return res.status(400).json({
+        ok: false,
+        error: 'Validation error',
+        details: error.details[0].message
+      });
+    }
+
+    const { page, limit, sortBy, sortOrder, state, startDate, endDate } = value;
+    const offset = (page - 1) * limit;
+
+    // Build where clause
+    const where: any = { campaignId };
+
+    if (state) {
+      where.state = state;
+    }
+
+    if (startDate || endDate) {
+      where.epochStart = {};
+      if (startDate) where.epochStart.gte = startDate;
+      if (endDate) where.epochStart.lte = endDate;
+    }
+
+    const epochs = await (prisma as any).campaignEpoch.findMany({
+      where,
+      include: {
+        _count: {
+          select: { payouts: true }
+        }
+      },
+      orderBy: { [sortBy]: sortOrder },
+      skip: offset,
+      take: limit
+    });
+
+    const totalCount = await (prisma as any).campaignEpoch.count({ where });
+
+    // Calculate additional stats for each epoch
+    const epochsWithStats = await Promise.all(
+      epochs.map(async (epoch) => {
+        // Get payout statistics for this epoch
+        const payoutStats = await prisma.payout.aggregate({
+          where: { epochId: epoch.id } as any,
+          _count: { id: true }
+        });
+
+        const completedPayouts = await prisma.payout.count({
+          where: { 
+            epochId: epoch.id,
+            status: 'COMPLETED'
+          } as any
+        });
+
+        // Get total payout amount for this epoch
+        const totalPayoutResult = await prisma.$queryRaw<[{ sum: bigint }]>`
+          SELECT COALESCE(SUM(CAST(amount AS BIGINT)), 0) as sum
+          FROM "Payout"
+          WHERE "epochId" = ${epoch.id}
+        `;
+        const totalPayoutAmount = totalPayoutResult[0]?.sum?.toString() || '0';
+
+        return {
+          ...epoch,
+          stats: {
+            totalPayouts: payoutStats._count.id || 0,
+            completedPayouts,
+            totalPayoutAmount,
+            remainingAmount: (BigInt(epoch.allocated) - BigInt(totalPayoutAmount)).toString()
+          }
+        };
+      })
+    );
+
+    res.json({
+      ok: true,
+      data: epochsWithStats,
+      pagination: {
+        page,
+        limit,
+        total: totalCount,
+        pages: Math.ceil(totalCount / limit)
+      }
+    });
+  } catch (error) {
+    console.error('Get campaign epochs error:', error);
+    res.status(500).json({
+      ok: false,
+      error: 'Internal server error'
+    });
+  }
+});
+
+// GET /api/epochs/:epochId - Get epoch details
+router.get('/:epochId', async (req: Request, res: Response) => {
+  try {
+    const { epochId } = req.params;
+
+    const epoch = await (prisma as any).campaignEpoch.findUnique({
+      where: { id: epochId },
+      include: {
+        campaign: {
+          select: {
+            id: true,
+            name: true,
+            tokenSymbol: true,
+            chainId: true
+          }
+        },
+        payouts: {
+          include: {
+            user: {
+              select: { id: true, displayName: true, wallet: true }
+            },
+            platformUser: {
+              select: { id: true, displayName: true, platform: true, platformId: true }
+            },
+            processedBy: {
+              select: { id: true, name: true, email: true }
+            }
+          },
+          orderBy: { createdAt: 'desc' }
+        }
+      }
+    });
+
+    if (!epoch) {
+      return res.status(404).json({
+        ok: false,
+        error: 'Epoch not found'
+      });
+    }
+
+    // Calculate detailed statistics
+    const payoutStats = await prisma.payout.aggregate({
+      where: { epochId: epoch.id } as any,
+      _count: { id: true }
+    });
+
+    const statusStats = await prisma.payout.groupBy({
+      by: ['status'],
+      where: { epochId: epoch.id } as any,
+      _count: { id: true }
+    });
+
+    // Get total payout amount
+    const totalPayoutResult = await prisma.$queryRaw<[{ sum: bigint }]>`
+      SELECT COALESCE(SUM(CAST(amount AS BIGINT)), 0) as sum
+      FROM "Payout"
+      WHERE "epochId" = ${epoch.id}
+    `;
+    const totalPayoutAmount = totalPayoutResult[0]?.sum?.toString() || '0';
+
+    res.json({
+      ok: true,
+      data: {
+        ...epoch,
+        stats: {
+          totalPayouts: payoutStats._count.id || 0,
+          totalPayoutAmount,
+          remainingAmount: (BigInt(epoch.allocated) - BigInt(totalPayoutAmount)).toString(),
+          statusBreakdown: statusStats.reduce((acc, stat) => {
+            acc[stat.status] = {
+              count: stat._count.id,
+              amount: '0' // We'll calculate this separately if needed
+            };
+            return acc;
+          }, {} as Record<string, { count: number; amount: string }>)
+        }
+      }
+    });
+  } catch (error) {
+    console.error('Get epoch details error:', error);
+    res.status(500).json({
+      ok: false,
+      error: 'Internal server error'
+    });
+  }
+});
+
+// POST /api/campaigns/:campaignId/epochs - Create new epoch
+router.post('/campaigns/:campaignId/epochs', async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const { campaignId } = req.params;
+    const { error, value } = createEpochSchema.validate(req.body);
+    
+    if (error) {
+      return res.status(400).json({
+        ok: false,
+        error: 'Validation error',
+        details: error.details[0].message
+      });
+    }
+
+    // Check if campaign exists
+    const campaign = await prisma.campaign.findUnique({
+      where: { id: campaignId }
+    });
+
+    if (!campaign) {
+      return res.status(404).json({
+        ok: false,
+        error: 'Campaign not found'
+      });
+    }
+
+    // Check if epoch number already exists for this campaign
+    const existingEpoch = await (prisma as any).campaignEpoch.findUnique({
+      where: {
+        campaignId_epochNumber: {
+          campaignId,
+          epochNumber: value.epochNumber
+        }
+      }
+    });
+
+    if (existingEpoch) {
+      return res.status(400).json({
+        ok: false,
+        error: `Epoch ${value.epochNumber} already exists for this campaign`
+      });
+    }
+
+    const epoch = await (prisma as any).campaignEpoch.create({
+      data: {
+        campaignId,
+        epochNumber: value.epochNumber,
+        epochStart: value.epochStart,
+        epochEnd: value.epochEnd,
+        claimWindowEnds: value.claimWindowEnds,
+        allocated: value.allocated,
+        state: value.state
+      }
+    });
+
+    res.status(201).json({
+      ok: true,
+      data: epoch,
+      message: 'Epoch created successfully'
+    });
+  } catch (error) {
+    console.error('Create epoch error:', error);
+    res.status(500).json({
+      ok: false,
+      error: 'Internal server error'
+    });
+  }
+});
+
+// PUT /api/epochs/:epochId - Update epoch
+router.put('/:epochId', async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const { epochId } = req.params;
+    const { error, value } = updateEpochSchema.validate(req.body);
+    
+    if (error) {
+      return res.status(400).json({
+        ok: false,
+        error: 'Validation error',
+        details: error.details[0].message
+      });
+    }
+
+    // Check if epoch exists
+    const existingEpoch = await (prisma as any).campaignEpoch.findUnique({
+      where: { id: epochId }
+    });
+
+    if (!existingEpoch) {
+      return res.status(404).json({
+        ok: false,
+        error: 'Epoch not found'
+      });
+    }
+
+    // Validate state transitions
+    const validTransitions: Record<string, string[]> = {
+      'OPEN': ['CLAIMING', 'CLOSED'],
+      'CLAIMING': ['RECYCLED', 'EXPIRED', 'CLOSED'],
+      'RECYCLED': ['CLOSED'],
+      'EXPIRED': ['CLOSED'],
+      'CLOSED': []
+    };
+
+    if (value.state && !validTransitions[existingEpoch.state]?.includes(value.state)) {
+      return res.status(400).json({
+        ok: false,
+        error: `Invalid state transition from ${existingEpoch.state} to ${value.state}`
+      });
+    }
+
+    const epoch = await (prisma as any).campaignEpoch.update({
+      where: { id: epochId },
+      data: value
+    });
+
+    res.json({
+      ok: true,
+      data: epoch,
+      message: 'Epoch updated successfully'
+    });
+  } catch (error) {
+    console.error('Update epoch error:', error);
+    res.status(500).json({
+      ok: false,
+      error: 'Internal server error'
+    });
+  }
+});
+
+export { router as epochRoutes };


### PR DESCRIPTION
Closes #103 

## Summary
Updated the admin-service backend API to support the new epoch-based campaign schema: display campaign/epoch/payout data and allow manual updates where permitted (no schedulers, no automated epoch creation/recycling here).


## Changes Made
- Updated campaign creation to support new fields (payoutIntervalSeconds, epochRewardCap, claimWindowSeconds, recycleUnclaimed)
- Added campaign funding endpoint (isFunded, vaultAddress, fundingTxHash, startDate)
- Added campaign status management (DRAFT, ACTIVE, PAUSED, COMPLETED, CANCELED)
- Updated campaign listing with epoch summary and funding status
- Add campaign details endpoint with epoch totals and remaining pool
- Epoch APIs
  - Created epoch listing endpoint for campaigns with filtering
  - Added epoch details endpoint with allocation/claimed amounts and payouts
  - Added manual epoch creation endpoint
  - Added manual epoch update endpoint with state/amount guards
  - Updated payout creation to support epochId linking